### PR TITLE
Suggestion: Add replacePrefix companion option for stripPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,14 @@ strip that prefix from the start of each local file's path in order to get the c
 
 Default: `''`
 
+### replacePrefix [String]
+Useful when you are using stripPrefix to remove some portion of the url, but instead of just removing it,
+need a replacement string to be used instead. Use this option if you are serving statics from a different directory.
+E.g. if all your local files are under `dist/app/` but your static asset root is at `/public/`, you'd
+strip 'dist/app/' and replace it with '/public/' in order to get the correct URL for the web.
+
+Default: `''`
+
 ### staticFileGlobs [Array&#x27e8;String&#x27e9;]
 An array of one or more string patterns that will be passed in to
 [`glob`](https://github.com/isaacs/node-glob).

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -70,6 +70,7 @@ function generate(params, callback) {
     logger: console.log,
     maximumFileSizeToCacheInBytes: 2 * 1024 * 1024, // 2MB
     stripPrefix: '',
+    replacePrefix: '',
     staticFileGlobs: [],
     templateFilePath: path.join(
       path.dirname(fs.realpathSync(__filename)), '..', 'service-worker.tmpl'),
@@ -91,7 +92,7 @@ function generate(params, callback) {
       if (fileAndSizeAndHash.size <= params.maximumFileSizeToCacheInBytes) {
         // Strip the prefix to turn this into a relative URL.
         var relativeUrl = fileAndSizeAndHash.file
-          .replace(params.stripPrefix, '')
+          .replace(params.stripPrefix, params.replacePrefix)
           .replace(path.sep, '/');
         relativeUrlToHash[relativeUrl] = fileAndSizeAndHash.hash;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sw-precache",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Generate service worker code that will precache specific resources.",
   "author": {
     "name": "Jeff Posnick",


### PR DESCRIPTION
A small extension to stripPrefix. While stripPrefix is useful, I found it more useful to be able to actually substitute for that prefix. My use case is a static asset directory in Node.
