### PR TITLE
Make the stripPrefix option only strip the prefix in a filename

### DIFF
--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -60,6 +60,11 @@ function getHash(data) {
   return md5.digest('hex');
 }
 
+// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function generate(params, callback) {
   params = defaults(params || {}, {
     cacheId: '',
@@ -93,7 +98,7 @@ function generate(params, callback) {
       if (fileAndSizeAndHash.size <= params.maximumFileSizeToCacheInBytes) {
         // Strip the prefix to turn this into a relative URL.
         var relativeUrl = fileAndSizeAndHash.file
-          .replace(params.stripPrefix, params.replacePrefix)
+          .replace(new RegExp("^" + escapeRegExp(params.stripPrefix)), params.replacePrefix)
           .replace(path.sep, '/');
         relativeUrlToHash[relativeUrl] = fileAndSizeAndHash.hash;
 

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -62,7 +62,7 @@ function getHash(data) {
 
 // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 function escapeRegExp(string) {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function generate(params, callback) {
@@ -98,7 +98,7 @@ function generate(params, callback) {
       if (fileAndSizeAndHash.size <= params.maximumFileSizeToCacheInBytes) {
         // Strip the prefix to turn this into a relative URL.
         var relativeUrl = fileAndSizeAndHash.file
-          .replace(new RegExp("^" + escapeRegExp(params.stripPrefix)), params.replacePrefix)
+          .replace(new RegExp('^' + escapeRegExp(params.stripPrefix)), params.replacePrefix)
           .replace(path.sep, '/');
         relativeUrlToHash[relativeUrl] = fileAndSizeAndHash.hash;
 

--- a/test/test.js
+++ b/test/test.js
@@ -135,7 +135,7 @@ describe('sw-precache core functionality', function() {
         'test/data/one/c.txt',
         'test/data/two/b.txt'
       ],
-      stripPrefix: ".",
+      stripPrefix: '.'
     };
 
     var configPrime = {
@@ -165,7 +165,7 @@ describe('sw-precache core functionality', function() {
         'test/data/one/c.txt',
         'test/data/two/b.txt'
       ],
-      stripPrefix: "test",
+      stripPrefix: 'test'
     };
 
     var configPrime = {

--- a/test/test.js
+++ b/test/test.js
@@ -127,6 +127,66 @@ describe('sw-precache core functionality', function() {
     });
   });
 
+  it('should produce the same output when stripPrefix doesn\'t match the file prefixes', function(done) {
+    var config = {
+      logger: NOOP,
+      staticFileGlobs: [
+        'test/data/one/a.txt',
+        'test/data/one/c.txt',
+        'test/data/two/b.txt'
+      ],
+      stripPrefix: ".",
+    };
+
+    var configPrime = {
+      logger: NOOP,
+      staticFileGlobs: [
+        'test/data/one/c.txt',
+        'test/data/two/b.txt',
+        'test/data/one/a.txt'
+      ]
+    };
+
+    generate(config, function(error, reponseString) {
+      assert.ifError(error);
+      generate(configPrime, function(error, responseStringPrime) {
+        assert.ifError(error);
+        assert.strictEqual(reponseString, responseStringPrime);
+        done();
+      });
+    });
+  });
+
+  it('should produce different output when stripPrefix matches the file prefixes', function(done) {
+    var config = {
+      logger: NOOP,
+      staticFileGlobs: [
+        'test/data/one/a.txt',
+        'test/data/one/c.txt',
+        'test/data/two/b.txt'
+      ],
+      stripPrefix: "test",
+    };
+
+    var configPrime = {
+      logger: NOOP,
+      staticFileGlobs: [
+        'test/data/one/c.txt',
+        'test/data/two/b.txt',
+        'test/data/one/a.txt'
+      ]
+    };
+
+    generate(config, function(error, reponseString) {
+      assert.ifError(error);
+      generate(configPrime, function(error, responseStringPrime) {
+        assert.ifError(error);
+        assert.notStrictEqual(reponseString, responseStringPrime);
+        done();
+      });
+    });
+  });
+
   after(function() {
     fs.unlinkSync(TEMP_FILE);
   });


### PR DESCRIPTION
Currently sw-precache is stripping the first occurrence of `stripPrefix`, but the first occurrence could be in the middle of the name.