### PR TITLE
Disables an additional lint check in the auto-generated SW file.

### DIFF
--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -21,7 +21,7 @@
 // for an example of how you can register this script and handle various service worker events.
 
 /* eslint-env worker, serviceworker */
-/* eslint-disable no-unused-vars, no-multiple-empty-lines, max-nested-callbacks, space-before-function-paren */
+/* eslint-disable indent, no-unused-vars, no-multiple-empty-lines, max-nested-callbacks, space-before-function-paren */
 'use strict';
 
 <% if (importScripts) { %>


### PR DESCRIPTION
Not exactly why this is wasn't an issue previously, but the `indent` rule should be disabled for the generated SW.

(This came up in the Travis CI build for https://github.com/GoogleChrome/sw-precache/pull/35)