### PR TITLE
Add promises compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,13 @@ The `sw-precache` module exposes two methods: `generate` and `write`.
 then invokes `callback(error, serviceWorkerString)`.
 In the 1.x releases of `sw-precache`, this was the default and only method exposed by the module.
 
+Since 2.2.0, `generate()` also returns an ES6 promise.
+
 ### write(filePath, options, callback)
 `write` is a helper method that calls `generate` and takes the resulting string content and
 writes it to disk, at `filePath`. It then invokes `callback(error)`.
 
+Since 2.2.0, `write()` also returns an ES6 promise.
 
 ## Options
 

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -26,6 +26,7 @@ var path = require('path');
 var prettyBytes = require('pretty-bytes');
 var template = require('lodash.template');
 var util = require('util');
+var Promise = require('es6-promise').Promise;
 
 // This should only change if there are breaking changes in the cache format used by the SW.
 var VERSION = 'v1';
@@ -61,120 +62,140 @@ function getHash(data) {
 }
 
 function generate(params, callback) {
-  params = defaults(params || {}, {
-    cacheId: '',
-    directoryIndex: 'index.html',
-    dynamicUrlToDependencies: {},
-    handleFetch: true,
-    ignoreUrlParametersMatching: [/^utm_/],
-    importScripts: [],
-    logger: console.log,
-    maximumFileSizeToCacheInBytes: 2 * 1024 * 1024, // 2MB
-    stripPrefix: '',
-    replacePrefix: '',
-    staticFileGlobs: [],
-    templateFilePath: path.join(
-      path.dirname(fs.realpathSync(__filename)), '..', 'service-worker.tmpl'),
-    verbose: false
-  });
+  return new Promise(function(resolve, reject) {
+    params = defaults(params || {}, {
+      cacheId: '',
+      directoryIndex: 'index.html',
+      dynamicUrlToDependencies: {},
+      handleFetch: true,
+      ignoreUrlParametersMatching: [/^utm_/],
+      importScripts: [],
+      logger: console.log,
+      maximumFileSizeToCacheInBytes: 2 * 1024 * 1024, // 2MB
+      stripPrefix: '',
+      replacePrefix: '',
+      staticFileGlobs: [],
+      templateFilePath: path.join(
+        path.dirname(fs.realpathSync(__filename)), '..', 'service-worker.tmpl'),
+      verbose: false
+    });
 
-  if (!Array.isArray(params.ignoreUrlParametersMatching)) {
-    params.ignoreUrlParametersMatching = [params.ignoreUrlParametersMatching];
-  }
+    if (!Array.isArray(params.ignoreUrlParametersMatching)) {
+      params.ignoreUrlParametersMatching = [params.ignoreUrlParametersMatching];
+    }
 
-  var relativeUrlToHash = {};
-  var cumulativeSize = 0;
+    var relativeUrlToHash = {};
+    var cumulativeSize = 0;
 
-  params.staticFileGlobs.forEach(function(globPattern) {
-    var filesAndSizesAndHashes = getFilesAndSizesAndHashesForGlobPattern(globPattern);
+    params.staticFileGlobs.forEach(function(globPattern) {
+      var filesAndSizesAndHashes = getFilesAndSizesAndHashesForGlobPattern(globPattern);
 
-    // The files returned from glob are sorted by default, so we don't need to sort here.
-    filesAndSizesAndHashes.forEach(function(fileAndSizeAndHash) {
-      if (fileAndSizeAndHash.size <= params.maximumFileSizeToCacheInBytes) {
-        // Strip the prefix to turn this into a relative URL.
-        var relativeUrl = fileAndSizeAndHash.file
-          .replace(params.stripPrefix, params.replacePrefix)
-          .replace(path.sep, '/');
-        relativeUrlToHash[relativeUrl] = fileAndSizeAndHash.hash;
+      // The files returned from glob are sorted by default, so we don't need to sort here.
+      filesAndSizesAndHashes.forEach(function(fileAndSizeAndHash) {
+        if (fileAndSizeAndHash.size <= params.maximumFileSizeToCacheInBytes) {
+          // Strip the prefix to turn this into a relative URL.
+          var relativeUrl = fileAndSizeAndHash.file
+            .replace(params.stripPrefix, params.replacePrefix)
+            .replace(path.sep, '/');
+          relativeUrlToHash[relativeUrl] = fileAndSizeAndHash.hash;
 
-        if (params.verbose) {
-          params.logger(util.format('Caching static resource "%s" (%s)', fileAndSizeAndHash.file,
-            prettyBytes(fileAndSizeAndHash.size)));
+          if (params.verbose) {
+            params.logger(util.format('Caching static resource "%s" (%s)', fileAndSizeAndHash.file,
+              prettyBytes(fileAndSizeAndHash.size)));
+          }
+
+          cumulativeSize += fileAndSizeAndHash.size;
+        } else {
+          params.logger(util.format('Skipping static resource "%s" (%s) - max size is %s',
+            fileAndSizeAndHash.file, prettyBytes(fileAndSizeAndHash.size),
+            prettyBytes(params.maximumFileSizeToCacheInBytes)));
         }
+      });
+    });
 
+    Object.keys(params.dynamicUrlToDependencies).forEach(function(dynamicUrl) {
+      var filesAndSizesAndHashes = params.dynamicUrlToDependencies[dynamicUrl]
+        .sort()
+        .map(getFileAndSizeAndHashForFile);
+      var concatenatedHashes = '';
+
+      filesAndSizesAndHashes.forEach(function(fileAndSizeAndHash) {
+        // Let's assume that the response size of a server-generated page is roughly equal to the
+        // total size of all its components.
         cumulativeSize += fileAndSizeAndHash.size;
-      } else {
-        params.logger(util.format('Skipping static resource "%s" (%s) - max size is %s',
-          fileAndSizeAndHash.file, prettyBytes(fileAndSizeAndHash.size),
-          prettyBytes(params.maximumFileSizeToCacheInBytes)));
+        concatenatedHashes += fileAndSizeAndHash.hash;
+      });
+
+      relativeUrlToHash[dynamicUrl] = getHash(concatenatedHashes);
+
+      if (params.verbose) {
+        params.logger(util.format('Caching dynamic URL "%s" with dependencies on %j',
+          dynamicUrl, params.dynamicUrlToDependencies[dynamicUrl]));
       }
     });
-  });
 
-  Object.keys(params.dynamicUrlToDependencies).forEach(function(dynamicUrl) {
-    var filesAndSizesAndHashes = params.dynamicUrlToDependencies[dynamicUrl]
-      .sort()
-      .map(getFileAndSizeAndHashForFile);
-    var concatenatedHashes = '';
-
-    filesAndSizesAndHashes.forEach(function(fileAndSizeAndHash) {
-      // Let's assume that the response size of a server-generated page is roughly equal to the
-      // total size of all its components.
-      cumulativeSize += fileAndSizeAndHash.size;
-      concatenatedHashes += fileAndSizeAndHash.hash;
+    // It's very important that running this operation multiple times with the same input files
+    // produces identical output, since we need the generated service-worker.js file to change iff
+    // the input files changes. The service worker update algorithm,
+    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#update-algorithm,
+    // relies on detecting even a single byte change in service-worker.js to trigger an update.
+    // Because of this, we write out the cache options as a series of sorted, nested arrays rather
+    // than as objects whose serialized key ordering might vary.
+    var relativeUrls = Object.keys(relativeUrlToHash);
+    var precacheConfig = relativeUrls.sort().map(function(relativeUrl) {
+      return [relativeUrl, relativeUrlToHash[relativeUrl]];
     });
 
-    relativeUrlToHash[dynamicUrl] = getHash(concatenatedHashes);
+    params.logger(util.format('Total precache size is about %s for %d resources.',
+      prettyBytes(cumulativeSize), relativeUrls.length));
 
-    if (params.verbose) {
-      params.logger(util.format('Caching dynamic URL "%s" with dependencies on %j',
-        dynamicUrl, params.dynamicUrlToDependencies[dynamicUrl]));
-    }
-  });
+    fs.readFile(params.templateFilePath, 'utf8', function(error, data) {
+      if (error) {
+        if (callback) {
+          callback(error);
+        }
 
-  // It's very important that running this operation multiple times with the same input files
-  // produces identical output, since we need the generated service-worker.js file to change iff
-  // the input files changes. The service worker update algorithm,
-  // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#update-algorithm,
-  // relies on detecting even a single byte change in service-worker.js to trigger an update.
-  // Because of this, we write out the cache options as a series of sorted, nested arrays rather
-  // than as objects whose serialized key ordering might vary.
-  var relativeUrls = Object.keys(relativeUrlToHash);
-  var precacheConfig = relativeUrls.sort().map(function(relativeUrl) {
-    return [relativeUrl, relativeUrlToHash[relativeUrl]];
-  });
+        return reject(error);
+      }
 
-  params.logger(util.format('Total precache size is about %s for %d resources.',
-    prettyBytes(cumulativeSize), relativeUrls.length));
+      var populatedTemplate = template(data)({
+        cacheId: params.cacheId,
+        // Ensure that anything false is translated into '', since this will be treated as a string.
+        directoryIndex: params.directoryIndex || '',
+        externalFunctions: externalFunctions,
+        handleFetch: params.handleFetch,
+        ignoreUrlParametersMatching: params.ignoreUrlParametersMatching,
+        importScripts: params.importScripts ? params.importScripts.map(JSON.stringify).join(',') : null,
+        precacheConfig: JSON.stringify(precacheConfig),
+        version: VERSION
+      });
 
-  fs.readFile(params.templateFilePath, 'utf8', function(error, data) {
-    if (error) {
-      return callback(error);
-    }
+      if (callback) {
+        callback(null, populatedTemplate);
+      }
 
-    var populatedTemplate = template(data)({
-      cacheId: params.cacheId,
-      // Ensure that anything false is translated into '', since this will be treated as a string.
-      directoryIndex: params.directoryIndex || '',
-      externalFunctions: externalFunctions,
-      handleFetch: params.handleFetch,
-      ignoreUrlParametersMatching: params.ignoreUrlParametersMatching,
-      importScripts: params.importScripts ? params.importScripts.map(JSON.stringify).join(',') : null,
-      precacheConfig: JSON.stringify(precacheConfig),
-      version: VERSION
+      resolve(populatedTemplate);
     });
-
-    callback(null, populatedTemplate);
   });
 }
 
 function write(filePath, params, callback) {
-  generate(params, function(error, serviceWorkerFileContents) {
-    if (error) {
-      return callback(error);
+  return new Promise(function(resolve, reject) {
+    function finish(error, value) {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(value);
+      }
+
+      if (callback) {
+        callback(error, value);
+      }
     }
 
-    fs.writeFile(filePath, serviceWorkerFileContents, callback);
+    generate(params).then(function(serviceWorkerFileContents) {
+      fs.writeFile(filePath, serviceWorkerFileContents, finish);
+    }, finish);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "dom-urls": "^1.0.0",
+    "es6-promise": "^3.0.2",
     "glob": "^5.0.10",
     "lodash.defaults": "^3.1.1",
     "lodash.template": "^3.6.1",

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,17 @@ describe('sw-precache core functionality', function() {
     });
   });
 
+  it('should return a promise that resolves with the same output', function(done) {
+    generate({logger: NOOP}).then(function(responseStringOne) {
+      generate({logger: NOOP}, function(error, responseStringTwo) {
+        assert.ifError(error);
+
+        assert.strictEqual(responseStringOne, responseStringTwo);
+        done();
+      });
+    }, assert.ifError);
+  });
+
   it('should produce the same output given the same input files', function(done) {
     var config = {
       logger: NOOP,
@@ -147,7 +158,18 @@ describe('sw-precache write functionality', function() {
     });
   });
 
-  after(function() {
+  it('should return a promise that resolves when the file has been written', function(done) {
+    write(SW_FILE, {logger: NOOP}).then(function() {
+      fs.stat(SW_FILE, function(error, stats) {
+        assert.ifError(error);
+        assert(stats.isFile(), 'file exists');
+        assert(stats.size > 0, 'file contains data');
+        done();
+      });
+    }, assert.ifError);
+  });
+
+  afterEach(function() {
     fs.unlinkSync(SW_FILE);
   });
 });


### PR DESCRIPTION
Currently you have to manually promisify sw-precache before using it with promise-driven libraries.

This PR adds full promise support out of the box, i.e you can now do:

```js
generate(options).then(function (serviceWorkerString) {
  // ...
}, function (error) {
   // ...
});

// or
write(filepath, options).then(function () {
  // ...
}, function (error) {
  // ...
});
```

The existing callback API still works the same as before.

I've added a note about the addition in the readme. I wrote "Since 0.2.2" because I'm assuming (if you choose to merge this) that you'll bump the minor version, as this is an API change, but a backwards compatible one.

**Caveats:** It adds one dependency – [es6-promise](https://www.npmjs.com/package/es6-promise) – because sw-precache declares support for `"node": ">=0.10.0"`, and Node didn't add promises till v0.12. On the plus side, es6-promise has no subdependencies.