### PR TITLE
Adds the navigateFallback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ Files larger than this size will not be added to the precache list.
 Default: `2097152` (2 megabytes)
 
 ### navigateFallback [String]
-If set, then a request for an HTML document whose URL doesn't otherwisematch any cached entries will
-be treated as if it were a request for the `navigateFallback` value, relative to the URL that the
-service worker is served from. To be effective, this fallback URL should be already cached via
+If set, then a request for an HTML document whose URL doesn't otherwise match any cached entries
+will be treated as if it were a request for the `navigateFallback` value, relative to the URL that
+the service worker is served from. To be effective, this fallback URL should be already cached via
 `staticFileGlobs` or `dynamicUrlToDependencies`.
 
 This comes in handy when used with a web application that performs client-side URL routing

--- a/README.md
+++ b/README.md
@@ -193,8 +193,29 @@ Files larger than this size will not be added to the precache list.
 
 Default: `2097152` (2 megabytes)
 
+### navigateFallback [String]
+If set, then a request for an HTML document whose URL doesn't otherwisematch any cached entries will
+be treated as if it were a request for the `navigateFallback` value, relative to the URL that the
+service worker is served from. To be effective, this fallback URL should be already cached via
+`staticFileGlobs` or `dynamicUrlToDependencies`.
+
+This comes in handy when used with a web application that performs client-side URL routing
+using the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History). It allows any
+arbitrary URL that the client generates to map to a fallback cached HTML entry. This fallback entry
+ideally should serve as an "application shell" that is able to load the appropriate resources
+client-side, based on the request URL.
+
+**Note**: The current implementation checks `event.request.headers.get('accept').includes('text/html')`
+to determine whether to trigger the fallback, which will be `true` for any request made for an
+HTML document, whether it's a navigation or not. Once it's more
+[widely](https://code.google.com/p/chromium/issues/detail?id=540967)
+[supported](https://bugzilla.mozilla.org/show_bug.cgi?id=1209081), the logic will be changed to
+check for `event.request.mode === 'navigate'`.
+
+Default: `''`
+
 ### stripPrefix [String]
-Useful when there's a discrepency between the relative path to a local file at build time and the
+Useful when there's a discrepancy between the relative path to a local file at build time and the
 relative URL that the resource will be served from.
 E.g. if all your local files are under `dist/app/` and your web root is also at `dist/app/`, you'd
 strip that prefix from the start of each local file's path in order to get the correct relative URL.

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -70,6 +70,7 @@ function generate(params, callback) {
     importScripts: [],
     logger: console.log,
     maximumFileSizeToCacheInBytes: 2 * 1024 * 1024, // 2MB
+    navigateFallback: '',
     stripPrefix: '',
     replacePrefix: '',
     staticFileGlobs: [],
@@ -160,6 +161,8 @@ function generate(params, callback) {
       handleFetch: params.handleFetch,
       ignoreUrlParametersMatching: params.ignoreUrlParametersMatching,
       importScripts: params.importScripts ? params.importScripts.map(JSON.stringify).join(',') : null,
+      // Ensure that anything false is translated into '', since this will be treated as a string.
+      navigateFallback: params.navigateFallback || '',
       precacheConfig: JSON.stringify(precacheConfig),
       version: VERSION
     });

--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -143,6 +143,16 @@ self.addEventListener('fetch', function(event) {
       cacheName = AbsoluteUrlToCacheName[urlWithoutIgnoredParameters];
     }
 
+    var navigateFallback = '<%= navigateFallback %>';
+    // Ideally, this would check for event.request.mode === 'navigate', but that is not widely
+    // supported yet:
+    // https://code.google.com/p/chromium/issues/detail?id=540967
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1209081
+    if (!cacheName && navigateFallback && event.request.headers.get('accept').includes('text/html')) {
+      var navigateFallbackUrl = new URL(navigateFallback, self.location);
+      cacheName = AbsoluteUrlToCacheName[navigateFallbackUrl.toString()];
+    }
+
     if (cacheName) {
       event.respondWith(
         // We can't call cache.match(event.request) since the entry in the cache will contain the

--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -148,7 +148,8 @@ self.addEventListener('fetch', function(event) {
     // supported yet:
     // https://code.google.com/p/chromium/issues/detail?id=540967
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1209081
-    if (!cacheName && navigateFallback && event.request.headers.get('accept').includes('text/html')) {
+    if (!cacheName && navigateFallback && event.request.headers.has('accept') &&
+        event.request.headers.get('accept').includes('text/html')) {
       var navigateFallbackUrl = new URL(navigateFallback, self.location);
       cacheName = AbsoluteUrlToCacheName[navigateFallbackUrl.toString()];
     }


### PR DESCRIPTION
R: @addyosmani @wibblymat 
CC: @slightlyoff

This adds an additional option that I found helpful when dealing with client-side routing in an app shell environment.

See the caveat about it being a bit more aggressive that it ideally would, since if set, it will be used as a fallback for all `text/html` requests, not just navigation requests.

