### PR TITLE
Friendlier error messages for two types of bad parameters.

### DIFF
--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -116,9 +116,29 @@ function generate(params, callback) {
     });
 
     Object.keys(params.dynamicUrlToDependencies).forEach(function(dynamicUrl) {
+      if (!Array.isArray(params.dynamicUrlToDependencies[dynamicUrl])) {
+        throw Error(util.format(
+          'The value for the dynamicUrlToDependencies.%s option must be an Array.', dynamicUrl));
+      }
+
       var filesAndSizesAndHashes = params.dynamicUrlToDependencies[dynamicUrl]
         .sort()
-        .map(getFileAndSizeAndHashForFile);
+        .map(function(file) {
+          try {
+            return getFileAndSizeAndHashForFile(file);
+          } catch(e) {
+            // Provide some additional information about the failure if the file is missing.
+            if (e.code === 'ENOENT') {
+              params.logger(util.format(
+                '%s was listed as a dependency for dynamic URL %s, but the file does not exist. ' +
+                'Either remove the entry as a dependency, or correct the path to the file.',
+                file, dynamicUrl
+              ));
+            }
+            // Re-throw the exception unconditionally, since this should be treated as fatal.
+            throw e;
+          }
+        });
       var concatenatedHashes = '';
 
       filesAndSizesAndHashes.forEach(function(fileAndSizeAndHash) {

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -126,7 +126,7 @@ function generate(params, callback) {
         .map(function(file) {
           try {
             return getFileAndSizeAndHashForFile(file);
-          } catch(e) {
+          } catch (e) {
             // Provide some additional information about the failure if the file is missing.
             if (e.code === 'ENOENT') {
               params.logger(util.format(


### PR DESCRIPTION
R: @gauntface @addyosmani 

This addresses two specific points that @gauntface raised in #43 

We are obviously a long way from proactively checking for every permutation of bad parameters and displaying a custom error response for each, vs. relying on the default exception handling to pick up and log (sometimes generic) failures. @gauntface, if you have an example of a JS library that you feel does this well right now—proactively checks for every permutation of bad parameters and displays a bespoke message for each—then I'd appreciate it if you could point me to it and I'll try to follow a similar approach.

The documentation improvements that @jpmedley is looking into can also help prevent developers from providing unexpected parameters to begin with.