### PR TITLE
Add remoteResources parameter to allow pre-caching third party remote resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,19 @@ You'll almost always want to specify something for this.
 
 _Default_: `[]`
 
+#### remoteResources [Array&#x27e8;String&#x27e9;]
+An optional array of URLs of remote resources to be automatically precached by the generated service worker.
+
+This can be used to cache frameworks loaded from CDNs. e.g. AngularJS.
+
+**Note**: To avoid the need for fetching remote resources and the additional
+build time this would add up to, it assumes that the resource URL is a unique
+identifier of the resource and the URL would change for an updated
+resource. If you want to force a cache update for the resource make sure to 
+update the URL, e.g. by adding revision number as a parameter. e.g. ?123
+
+_Default_: `[]`
+
 #### templateFilePath [String]
 
 The path to the  ([lo-dash](https://lodash.com/docs#template)) template used to

--- a/demo/app/index.html
+++ b/demo/app/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html ng-app="app">
   <head>
     <meta charset="utf-8">
     <title>Service Worker Precache Test</title>
@@ -18,6 +18,11 @@
     <p>Here's a precached image:</p>
     <img src="images/one.png">
 
+    <p>You can also precache remote resources, this demo precache AngularJS loaded from Google CDN.</p>
+    <ul ng-controller="MainCtrl">
+      <li ng-repeat="item in items" ng-bind="item"></li>
+    </ul>
+
     <p>
       Try stopping the local web server (if you're accessing the <code>dist</code> version of this
       site via <code>localhost</code>) and disabling your network connection,
@@ -30,6 +35,8 @@
     </div>
 
     <script src="js/service-worker-registration.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.17/angular.min.js"></script>
+    <script src="js/app.js"></script>
     <script>
       function sendMessage(message) {
         return new Promise(function(resolve, reject) {

--- a/demo/app/js/app.js
+++ b/demo/app/js/app.js
@@ -1,0 +1,11 @@
+/* eslint-disable no-unused-vars */
+/* global angular:true */
+
+var app = angular.module('app', []);
+
+app.controller('MainCtrl', ['$scope', function($scope) {
+  $scope.items = [
+    'AngularJS is cached',
+    'And ready to be used offline'
+  ];
+}]);

--- a/demo/gulpfile.js
+++ b/demo/gulpfile.js
@@ -58,6 +58,9 @@ function writeServiceWorkerFile(rootDir, handleFetch, callback) {
       rootDir + '/images/**.*',
       rootDir + '/js/**.js'
     ],
+    remoteResources: [
+      'https://ajax.googleapis.com/ajax/libs/angularjs/1.3.17/angular.min.js'
+    ],
     stripPrefix: rootDir + '/',
     // verbose defaults to false, but for the purposes of this demo, log more.
     verbose: true

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -82,6 +82,7 @@ function generate(params, callback) {
       stripPrefix: '',
       replacePrefix: '',
       staticFileGlobs: [],
+      remoteResources: [],
       templateFilePath: path.join(
         path.dirname(fs.realpathSync(__filename)), '..', 'service-worker.tmpl'),
       verbose: false
@@ -158,6 +159,19 @@ function generate(params, callback) {
       if (params.verbose) {
         params.logger(util.format('Caching dynamic URL "%s" with dependencies on %j',
           dynamicUrl, params.dynamicUrlToDependencies[dynamicUrl]));
+      }
+    });
+
+    params.remoteResources.forEach(function(resource) {
+      // To avoid the need for fetching remote resources and the additional
+      // build time this would add to, assume that the resource URL is a unique
+      // identifier of the resource and the URL would change for an updated
+      // resource.
+      var urlHash = getHash(resource);
+      relativeUrlToHash[resource] = urlHash;
+
+      if (params.verbose) {
+        params.logger(util.format('Caching remote resource "%s"', resource));
       }
     });
 


### PR DESCRIPTION
This allows people to pre-cache frameworks and external resources loaded remotely from CDNs like AngularJS from Google CDN or jQuery or others. 
