### PR TITLE
Removes console.log()s from the generated SW

### DIFF
--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -72,7 +72,6 @@ self.addEventListener('install', function(event) {
           url.search += 'sw-precache=' + now;
           var urlWithCacheBusting = url.toString();
 
-          console.log('Adding URL "%s" to cache named "%s"', urlWithCacheBusting, cacheName);
           return caches.open(cacheName).then(function(cache) {
             var request = new Request(urlWithCacheBusting, {credentials: 'same-origin'});
             return fetch(request.clone()).then(function(response) {
@@ -93,7 +92,6 @@ self.addEventListener('install', function(event) {
             return cacheName.indexOf(CacheNamePrefix) === 0 &&
                    !(cacheName in CurrentCacheNamesToAbsoluteUrl);
           }).map(function(cacheName) {
-            console.log('Deleting out-of-date cache "%s"', cacheName);
             return caches.delete(cacheName);
           })
         );


### PR DESCRIPTION
R: @gauntface @addyosmani @wibblymat 
CC: @seanislegend

These log statements were mainly useful ~1 year ago when the service worker DevTools situation was much more, and you really needed logging to figure out what was going on regarding your caches. Things have improved (in Chrome) since then, and I think we can just drop this noise.

The existing `verbose` option is meant for toggling build-time logging, not run-time logging. I'd rather not creating a `runtime-verbose` option.

Closes #60 