### PR TITLE
Remove call to registration.update() from demo

### DIFF
--- a/demo/app/js/service-worker-registration.js
+++ b/demo/app/js/service-worker-registration.js
@@ -22,19 +22,12 @@ if ('serviceWorker' in navigator) {
   // It won't be able to control pages unless it's located at the same level or higher than them.
   // *Don't* register service worker file in, e.g., a scripts/ sub-directory!
   // See https://github.com/slightlyoff/ServiceWorker/issues/468
-  navigator.serviceWorker.register('service-worker.js')
-  .then(function(registration) {
-    // Check to see if there's an updated version of service-worker.js with new files to cache:
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-update-method
-    if (typeof registration.update === 'function') {
-      registration.update();
-    }
-
+  navigator.serviceWorker.register('service-worker.js').then(function(reg) {
     // updatefound is fired if service-worker.js changes.
-    registration.onupdatefound = function() {
-      // The updatefound event implies that registration.installing is set; see
+    reg.onupdatefound = function() {
+      // The updatefound event implies that reg.installing is set; see
       // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-container-updatefound-event
-      var installingWorker = registration.installing;
+      var installingWorker = reg.installing;
 
       installingWorker.onstatechange = function() {
         switch (installingWorker.state) {


### PR DESCRIPTION
R: @gauntface @wibblymat @addyosmani 

There's no need to call `registration.update()`, and I think its presence has caused some confusion (see https://github.com/mozilla/oghliner/pull/224).

This also shortens the name of the `registration` parameter down to `reg` to make it easier to adhere to the new 80 character line length.