### PR TITLE
Support for CLI configuration in an external JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ $ sw-precache --root=dist --static-file-globs='dist/**/*.html'
 to your shell (such as the `*` characters in the sample command line above,
 for example).
 
+Finally, there's support for storing a complex configuration in an external
+JSON file, using `--config <file>`. Any of the options from the file can be
+overridden via a command-line flag. For example,
+
+```sh
+$ sw-precache --config=path/to/sw-precache-config.json --verbose --no-handle-fetch
+```
+
+will generate a service worker file using the options provided in the
+`path/to/sw-precache-config.json` file, but with the `verbose` option set to
+`true` and the `handleFetch` option set to `false`.
+
 ## API
 
 ### Methods

--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ will generate a service worker file using the options provided in the
 `path/to/sw-precache-config.json` file, but with the `verbose` option set to
 `true` and the `handleFetch` option set to `false`.
 
+`sw-precache-config.json` might look like:
+
+```json
+{
+  "staticFileGlobs": [
+    "app/css/**.css",
+    "app/**.html",
+    "app/images/**.*",
+    "app/js/**.js"
+  ],
+  "stripPrefix": "app/"
+}
+```
+
 ## API
 
 ### Methods

--- a/cli.js
+++ b/cli.js
@@ -22,40 +22,75 @@ var meow = require('meow');
 var path = require('path');
 var swPrecache = require('./');
 
-function setDefaults(cli) {
-  cli.flags.root = cli.flags.root || './';
-  if (cli.flags.root.lastIndexOf('/') !== cli.flags.root.length - 1) {
-    cli.flags.root += '/';
-  }
-  cli.flags.stripPrefix = cli.flags.stripPrefix || cli.flags.root;
-  cli.flags.swFile = cli.flags.swFile || 'service-worker.js';
-  cli.flags.swFilePath = path.join(cli.flags.root, cli.flags.swFile);
-  cli.flags.staticFileGlobs = cli.flags.staticFileGlobs ?
-    [cli.flags.staticFileGlobs] : [cli.flags.root + '/**/*.*'];
-  cli.flags.cacheId = cli.flags.cacheId || cli.pkg.name;
-  if (cli.flags.ignoreUrlParametersMatching) {
-    cli.flags.ignoreUrlParametersMatching =
-      cli.flags.ignoreUrlParametersMatching.split(',').map(
-        function(s) {
-          return new RegExp(s);
-        }
-      );
-  }
-  if (cli.flags.importScripts) {
-    cli.flags.importScripts = cli.flags.importScripts.split(',');
+function setDefaults(cli, configFileFlags) {
+  var compositeFlags = cli.flags;
+
+  compositeFlags.root = compositeFlags.root || configFileFlags.root || './';
+  if (compositeFlags.root.lastIndexOf('/') !== compositeFlags.root.length - 1) {
+    compositeFlags.root += '/';
   }
 
-  return cli.flags;
+  compositeFlags.stripPrefix = compositeFlags.stripPrefix ||
+    configFileFlags.stripPrefix || compositeFlags.root;
+
+  compositeFlags.swFile = compositeFlags.swFile || configFileFlags.swFile ||
+    'service-worker.js';
+  compositeFlags.swFilePath = path.join(compositeFlags.root,
+    compositeFlags.swFile);
+
+  compositeFlags.cacheId = compositeFlags.cacheId ||
+    configFileFlags.cacheId || cli.pkg.name;
+
+  compositeFlags.staticFileGlobs = compositeFlags.staticFileGlobs ||
+    configFileFlags.staticFileGlobs;
+  if (compositeFlags.staticFileGlobs) {
+    if (typeof compositeFlags.staticFileGlobs === 'string') {
+      compositeFlags.staticFileGlobs = [compositeFlags.staticFileGlobs];
+    }
+  } else {
+    compositeFlags.staticFileGlobs = [compositeFlags.root + '/**/*.*'];
+  }
+
+  compositeFlags.ignoreUrlParametersMatching =
+    compositeFlags.ignoreUrlParametersMatching ||
+    configFileFlags.ignoreUrlParametersMatching;
+  if (compositeFlags.ignoreUrlParametersMatching &&
+      typeof compositeFlags.ignoreUrlParametersMatching === 'string') {
+    compositeFlags.ignoreUrlParametersMatching =
+      compositeFlags.ignoreUrlParametersMatching.split(',').map(function(s) {
+        return new RegExp(s);
+      });
+  }
+
+  compositeFlags.importScripts = compositeFlags.importScripts ||
+    configFileFlags.importScripts;
+  if (compositeFlags.importScripts &&
+      typeof compositeFlags.importScripts === 'string') {
+    compositeFlags.importScripts = compositeFlags.importScripts.split(',');
+  }
+
+  return compositeFlags;
 }
 
 var cli = meow({
-  help: 'Options from https://github.com/GoogleChrome/sw-precache#options are accepted as flags.'
+  help: 'Options from https://github.com/GoogleChrome/sw-precache#options ' +
+        'are accepted as flags.\nAlterantively, use --config <file>, where ' +
+        '<file> is the path to the JSON data representing the same options.\n' +
+        'When both a config file and command line option is given, the ' +
+        'command line option takes precedence.'
 });
-var options = setDefaults(cli);
+
+// If the --config option is used, then read the options from an external
+// JSON configuration file. Options from the --config file can be overwritten
+// by any command line options.
+var configFileFlags = cli.flags.config ?
+  require(path.resolve(cli.flags.config)) : {};
+var options = setDefaults(cli, configFileFlags);
 
 swPrecache.write(options.swFilePath, options, function(error) {
   if (error) {
-    throw error;
+    console.error(error.stack);
+    process.exit(1);
   }
 
   console.log(options.swFilePath,

--- a/cli.js
+++ b/cli.js
@@ -74,7 +74,7 @@ function setDefaults(cli, configFileFlags) {
 
 var cli = meow({
   help: 'Options from https://github.com/GoogleChrome/sw-precache#options ' +
-        'are accepted as flags.\nAlterantively, use --config <file>, where ' +
+        'are accepted as flags.\nAlternatively, use --config <file>, where ' +
         '<file> is the path to the JSON data representing the same options.\n' +
         'When both a config file and command line option is given, the ' +
         'command line option takes precedence.'

--- a/demo/sw-precache-config.json
+++ b/demo/sw-precache-config.json
@@ -1,0 +1,20 @@
+{
+  "dynamicUrlToDependencies": {
+    "dynamic/page1": [
+      "app/views/layout.jade",
+      "app/views/page1.jade"
+    ],
+    "dynamic/page2": [
+      "app/views/layout.jade",
+      "app/views/page2.jade"
+    ]
+  },
+  "staticFileGlobs": [
+    "app/css/**.css",
+    "app/**.html",
+    "app/images/**.*",
+    "app/js/**.js"
+  ],
+  "stripPrefix": "app/",
+  "verbose": true
+}


### PR DESCRIPTION
R: @addyosmani @gauntface @wibblymat 

I can see this as being useful for developers who prefer the CLI and want a reasonable way of specifying options, other than having to provide them all as command line flags.

It supports overriding the config file options with additional flags, making it easy to have, e.g., a `dev` build with `--no-handle-fetch` and `--verbose` set.

Closes #79 