### PR TITLE
User regexp literals instead of new RegExp

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -128,10 +128,10 @@ use for runtime requests that match specific URL patterns:
 ```js
 {
   runtimeCaching: [{
-    urlPattern: new RegExp('^https://example\.com/api'),
+    urlPattern: /^https:\/\/example\.com\/api/,
     handler: 'networkFirst'
   }, {
-    urlPattern: new RegExp('/articles/'),
+    urlPattern: /\/articles\//,
     handler: 'fastest',
     options: {
         cache: {

--- a/README.md
+++ b/README.md
@@ -355,10 +355,10 @@ that match `/articles/`:
 
 ```js
 runtimeCaching: [{
-  urlPattern: new RegExp('^https://example\.com/api'),
+  urlPattern: /^https:\/\/example\.com\/api/,
   handler: 'networkFirst'
 }, {
-  urlPattern: new RegExp('/articles/'),
+  urlPattern: /\/articles\//,
   handler: 'fastest',
   options: {
     cache: {


### PR DESCRIPTION
R: @petele

This works around escaping oddness in older versions of Node with `new RegExp(string)`.