### PR TITLE
Remove the sourcemap comment when inlining sw-toolbox

### DIFF
--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -174,7 +174,8 @@ function generate(params, callback) {
     var swToolboxCode;
     if (params.runtimeCaching) {
       var pathToSWToolbox = require.resolve('sw-toolbox/sw-toolbox.js');
-      swToolboxCode = fs.readFileSync(pathToSWToolbox, 'utf8');
+      swToolboxCode = fs.readFileSync(pathToSWToolbox, 'utf8')
+        .replace('//# sourceMappingURL=sw-toolbox.map.json', '');
 
       runtimeCaching = params.runtimeCaching.reduce(function(prev, curr) {
         var line;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sw-precache",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Generate service worker code that will precache specific resources.",
   "author": {
     "name": "Jeff Posnick",


### PR DESCRIPTION
R: @addyosmani @wibblymat @gauntface 

We can't rely on users including the `sw-toolbox` sourcemap file at a specific location in their web server when using `sw-precache` to inline the `sw-toolbox` code. This PR removes the reference to the sourcemap file to stop errors from being logged in the JS console.

A more robust solution is tracked in #95.

Closes #93 