### PR TITLE
Exclude the file passed to write() from being picked up

### DIFF
--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -25,12 +25,17 @@ var glob = require('glob');
 var mkdirp = require('mkdirp');
 var path = require('path');
 var prettyBytes = require('pretty-bytes');
+var process = require('process');
 var template = require('lodash.template');
 var util = require('util');
 require('es6-promise').polyfill();
 
 // This should only change if there are breaking changes in the cache format used by the SW.
 var VERSION = 'v1';
+
+function absolutePath(relativePath) {
+  return path.resolve(process.cwd(), relativePath);
+}
 
 function getFileAndSizeAndHashForFile(file) {
   var stat = fs.statSync(file);
@@ -47,9 +52,13 @@ function getFileAndSizeAndHashForFile(file) {
   return null;
 }
 
-function getFilesAndSizesAndHashesForGlobPattern(globPattern) {
+function getFilesAndSizesAndHashesForGlobPattern(globPattern, excludeFilePath) {
   return glob.sync(globPattern.replace(path.sep, '/')).map(function(file) {
-    return getFileAndSizeAndHashForFile(file);
+    // Return null if we want to exclude this file, and it will be excluded in
+    // the subsequent filter().
+    return excludeFilePath === absolutePath(file) ?
+      null :
+      getFileAndSizeAndHashForFile(file);
   }).filter(function(fileAndSizeAndHash) {
     return fileAndSizeAndHash !== null;
   });
@@ -95,8 +104,8 @@ function generate(params, callback) {
     var cumulativeSize = 0;
 
     params.staticFileGlobs.forEach(function(globPattern) {
-      var filesAndSizesAndHashes =
-        getFilesAndSizesAndHashesForGlobPattern(globPattern);
+      var filesAndSizesAndHashes = getFilesAndSizesAndHashesForGlobPattern(
+        globPattern, params.outputFilePath);
 
       // The files returned from glob are sorted by default, so we don't need to sort here.
       filesAndSizesAndHashes.forEach(function(fileAndSizeAndHash) {
@@ -278,6 +287,11 @@ function write(filePath, params, callback) {
     }
 
     mkdirp.sync(path.dirname(filePath));
+
+    // Keep track of where we're outputting the file to ensure that we don't
+    // pick up a previously written version in our new list of files.
+    // See https://github.com/GoogleChrome/sw-precache/issues/101
+    params.outputFilePath = absolutePath(filePath);
 
     generate(params).then(function(serviceWorkerFileContents) {
       fs.writeFile(filePath, serviceWorkerFileContents, finish);

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -25,7 +25,6 @@ var glob = require('glob');
 var mkdirp = require('mkdirp');
 var path = require('path');
 var prettyBytes = require('pretty-bytes');
-var process = require('process');
 var template = require('lodash.template');
 var util = require('util');
 require('es6-promise').polyfill();


### PR DESCRIPTION
R: @gauntface @wibblymat @addyosmani 
CC: @stuartlangridge

This ensures that a previously generated version of the service worker output file isn't picked up in the list of files to be precached.

*Insert "We need to go deeper!" meme here.*

Fixes #101