### PR TITLE
Properly read in runtimeCaching option from external config file

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -69,6 +69,9 @@ function setDefaults(cli, configFileFlags) {
     compositeFlags.importScripts = compositeFlags.importScripts.split(',');
   }
 
+  compositeFlags.runtimeCaching = compositeFlags.runtimeCaching ||
+    configFileFlags.runtimeCaching;
+
   return compositeFlags;
 }
 

--- a/demo/sw-precache-config.json
+++ b/demo/sw-precache-config.json
@@ -16,5 +16,9 @@
     "app/js/**.js"
   ],
   "stripPrefix": "app/",
-  "verbose": true
+  "verbose": true,
+  "runtimeCaching": [{
+    "urlPattern": "/this\\.is\\.a\\.regex/",
+    "handler": "networkFirst"
+  }]
 }


### PR DESCRIPTION
R: @wibblymat @gauntface @addyosmani 

Unfortunately, I need to add in special-case handling for each option being read by the command line interface from an external JSON config file.

Closes #109 