### PR TITLE
chore(cli): add "maximumFileSizeToCacheInBytes"

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -72,6 +72,9 @@ function setDefaults(cli, configFileFlags) {
   compositeFlags.runtimeCaching = compositeFlags.runtimeCaching ||
     configFileFlags.runtimeCaching;
 
+    compositeFlags.maximumFileSizeToCacheInBytes = compositeFlags.maximumFileSizeToCacheInBytes ||
+    configFileFlags.maximumFileSizeToCacheInBytes;
+
   return compositeFlags;
 }
 

--- a/cli.js
+++ b/cli.js
@@ -72,7 +72,7 @@ function setDefaults(cli, configFileFlags) {
   compositeFlags.runtimeCaching = compositeFlags.runtimeCaching ||
     configFileFlags.runtimeCaching;
 
-    compositeFlags.maximumFileSizeToCacheInBytes = compositeFlags.maximumFileSizeToCacheInBytes ||
+  compositeFlags.maximumFileSizeToCacheInBytes = compositeFlags.maximumFileSizeToCacheInBytes ||
     configFileFlags.maximumFileSizeToCacheInBytes;
 
   return compositeFlags;


### PR DESCRIPTION
The `maximumFileSizeToCacheInBytes` flag was ignored by the CLI :
``` 
{
  ...
  "maximumFileSizeToCacheInBytes": 4194304
}
```