### PR TITLE
Move to a single cache for all responses

### DIFF
--- a/demo/app/js/a.js
+++ b/demo/app/js/a.js
@@ -1,2 +1,2 @@
 /* eslint-disable no-unused-vars */
-var a1;
+var a;

--- a/demo/app/js/a.js
+++ b/demo/app/js/a.js
@@ -1,2 +1,2 @@
 /* eslint-disable no-unused-vars */
-var a;
+var a1;

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -42,22 +42,11 @@ module.exports = {
     return url.toString();
   },
 
-  populateCurrentCacheNames: function(precacheConfig,
-    cacheNamePrefix, baseUrl) {
-    var absoluteUrlToCacheName = {};
-    var currentCacheNamesToAbsoluteUrl = {};
-
-    precacheConfig.forEach(function(cacheOption) {
-      var absoluteUrl = new URL(cacheOption[0], baseUrl).toString();
-      var cacheName = cacheNamePrefix + absoluteUrl + '-' + cacheOption[1];
-      currentCacheNamesToAbsoluteUrl[cacheName] = absoluteUrl;
-      absoluteUrlToCacheName[absoluteUrl] = cacheName;
-    });
-
-    return {
-      absoluteUrlToCacheName: absoluteUrlToCacheName,
-      currentCacheNamesToAbsoluteUrl: currentCacheNamesToAbsoluteUrl
-    };
+  createCacheKey: function(originalUrl, paramName, paramValue) {
+    // Create a new URL object to avoid modifying originalUrl.
+    var url = new URL(originalUrl);
+    url.search += (url.search ? '&' : '') + paramName + '=' + paramValue;
+    return url.toString();
   },
 
   addDirectoryIndex: function(originalUrl, index) {
@@ -66,16 +55,6 @@ module.exports = {
       url.pathname += index;
     }
     return url.toString();
-  },
-
-  getCacheBustedUrl: function(url, param) {
-    param = param || Date.now();
-
-    var urlWithCacheBusting = new URL(url);
-    urlWithCacheBusting.search += (urlWithCacheBusting.search ? '&' : '') +
-      'sw-precache=' + param;
-
-    return urlWithCacheBusting.toString();
   },
 
   isPathWhitelisted: function(whitelist, absoluteUrlString) {

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -42,13 +42,6 @@ module.exports = {
     return url.toString();
   },
 
-  createCacheKey: function(originalUrl, paramName, paramValue) {
-    // Create a new URL object to avoid modifying originalUrl.
-    var url = new URL(originalUrl);
-    url.search += (url.search ? '&' : '') + paramName + '=' + paramValue;
-    return url.toString();
-  },
-
   addDirectoryIndex: function(originalUrl, index) {
     var url = new URL(originalUrl);
     if (url.pathname.slice(-1) === '/') {
@@ -68,5 +61,13 @@ module.exports = {
     return whitelist.some(function(whitelistedPathRegex) {
       return path.match(whitelistedPathRegex);
     });
+  },
+
+  createCacheKey: function(originalUrl, paramName, paramValue) {
+    // Create a new URL object to avoid modifying originalUrl.
+    var url = new URL(originalUrl);
+    url.search += (url.search ? '&' : '') +
+      encodeURIComponent(paramName) + '=' + encodeURIComponent(paramValue);
+    return url.toString();
   }
 };

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -30,7 +30,7 @@ var util = require('util');
 require('es6-promise').polyfill();
 
 // This should only change if there are breaking changes in the cache format used by the SW.
-var VERSION = 'v1';
+var VERSION = 'v2';
 
 function absolutePath(relativePath) {
   return path.resolve(process.cwd(), relativePath);

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -181,7 +181,7 @@ function generate(params, callback) {
     var runtimeCaching;
     var swToolboxCode;
     if (params.runtimeCaching) {
-      var pathToSWToolbox = require.resolve('sw-toolbox/build/sw-toolbox.js');
+      var pathToSWToolbox = require.resolve('sw-toolbox/sw-toolbox.js');
       swToolboxCode = fs.readFileSync(pathToSWToolbox, 'utf8')
         .replace('//# sourceMappingURL=sw-toolbox.map.json', '');
 

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -181,7 +181,7 @@ function generate(params, callback) {
     var runtimeCaching;
     var swToolboxCode;
     if (params.runtimeCaching) {
-      var pathToSWToolbox = require.resolve('sw-toolbox/sw-toolbox.js');
+      var pathToSWToolbox = require.resolve('sw-toolbox/build/sw-toolbox.js');
       swToolboxCode = fs.readFileSync(pathToSWToolbox, 'utf8')
         .replace('//# sourceMappingURL=sw-toolbox.map.json', '');
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "meow": "^3.3.0",
     "mkdirp": "^0.5.1",
     "pretty-bytes": "^3.0.1",
-    "sw-toolbox": "^3.1.1"
+    "sw-toolbox": "^3.2.0"
   },
   "repository": "googlechrome/sw-precache",
   "bugs": "https://github.com/googlechrome/sw-precache/issues",

--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -74,7 +74,6 @@ self.addEventListener('install', function(event) {
           Array.from(UrlsToCacheKeys.values()).map(function(cacheKey) {
             // If we don't have a key matching url in the cache already, add it.
             if (!cachedUrls.has(cacheKey)) {
-              console.log('Adding:', cacheKey);
               return cache.add(new Request(cacheKey, {credentials: 'same-origin'}));
             }
           })
@@ -96,7 +95,6 @@ self.addEventListener('activate', function(event) {
         return Promise.all(
           existingRequests.map(function(existingRequest) {
             if (!setOfExpectedUrls.has(existingRequest.url)) {
-              console.log('Deleting:', existingRequest.url);
               return cache.delete(existingRequest);
             }
           })
@@ -116,15 +114,21 @@ self.addEventListener('fetch', function(event) {
     // handlers a chance to handle the request if need be.
     var shouldRespond;
 
+    // First, remove all the ignored parameter and see if we have that URL
+    // in our cache. If so, great! shouldRespond will be true.
     var url = stripIgnoredUrlParameters(event.request.url, IgnoreUrlParametersMatching);
     shouldRespond = UrlsToCacheKeys.has(url);
 
+    // If shouldRespond is false, check again, this time with 'index.html'
+    // (or whatever the directoryIndex option is set to) at the end.
     var directoryIndex = '<%= directoryIndex %>';
     if (!shouldRespond && directoryIndex) {
       url = addDirectoryIndex(url, directoryIndex);
       shouldRespond = UrlsToCacheKeys.has(url);
     }
 
+    // If shouldRespond is still false, check to see if this is a navigation
+    // request, and if so, whether the URL matches navigateFallbackWhitelist.
     var navigateFallback = '<%= navigateFallback %>';
     if (!shouldRespond &&
         navigateFallback &&
@@ -134,11 +138,15 @@ self.addEventListener('fetch', function(event) {
       shouldRespond = UrlsToCacheKeys.has(url);
     }
 
+    // If shouldRespond was set to true at any point, then call
+    // event.respondWith(), using the appropriate cache key.
     if (shouldRespond) {
       event.respondWith(
         caches.open(CacheName).then(function(cache) {
           return cache.match(UrlsToCacheKeys.get(url));
         }).catch(function(e) {
+          // Fall back to just fetch()ing the request if some unexpected error
+          // prevented the cached response from being valid.
           console.warn('Couldn\'t serve response for "%s" from cache: %O', event.request.url, e);
           return fetch(event.request);
         })

--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -34,24 +34,24 @@
 importScripts(<%= importScripts %>);
 <% } %>
 
-var PrecacheConfig = <%= precacheConfig %>;
-var CacheName = 'sw-precache-<%= version %>-<%= cacheId %>-' + (self.registration ? self.registration.scope : '');
+var precacheConfig = <%= precacheConfig %>;
+var cacheName = 'sw-precache-<%= version %>-<%= cacheId %>-' + (self.registration ? self.registration.scope : '');
 
 <% if (handleFetch) { %>
-var IgnoreUrlParametersMatching = [<%= ignoreUrlParametersMatching %>];
+var ignoreUrlParametersMatching = [<%= ignoreUrlParametersMatching %>];
 <% } %>
 
 <% Object.keys(externalFunctions).sort().forEach(function(functionName) {%>
 var <%- functionName %> = <%= externalFunctions[functionName] %>;
 <% }); %>
 
-var HashParamName = '_sw-precache';
-var UrlsToCacheKeys = new Map(
-  PrecacheConfig.map(function(item) {
+var hashParamName = '_sw-precache';
+var urlsToCacheKeys = new Map(
+  precacheConfig.map(function(item) {
     var relativeUrl = item[0];
     var hash = item[1];
     var absoluteUrl = new URL(relativeUrl, self.location);
-    var cacheKey = createCacheKey(absoluteUrl, HashParamName, hash);
+    var cacheKey = createCacheKey(absoluteUrl, hashParamName, hash);
     return [absoluteUrl.toString(), cacheKey];
   })
 );
@@ -68,10 +68,10 @@ function setOfCachedUrls(cache) {
 
 self.addEventListener('install', function(event) {
   event.waitUntil(
-    caches.open(CacheName).then(function(cache) {
+    caches.open(cacheName).then(function(cache) {
       return setOfCachedUrls(cache).then(function(cachedUrls) {
         return Promise.all(
-          Array.from(UrlsToCacheKeys.values()).map(function(cacheKey) {
+          Array.from(urlsToCacheKeys.values()).map(function(cacheKey) {
             // If we don't have a key matching url in the cache already, add it.
             if (!cachedUrls.has(cacheKey)) {
               return cache.add(new Request(cacheKey, {credentials: 'same-origin'}));
@@ -87,10 +87,10 @@ self.addEventListener('install', function(event) {
 });
 
 self.addEventListener('activate', function(event) {
-  var setOfExpectedUrls = new Set(UrlsToCacheKeys.values());
+  var setOfExpectedUrls = new Set(urlsToCacheKeys.values());
 
   event.waitUntil(
-    caches.open(CacheName).then(function(cache) {
+    caches.open(cacheName).then(function(cache) {
       return cache.keys().then(function(existingRequests) {
         return Promise.all(
           existingRequests.map(function(existingRequest) {
@@ -116,15 +116,15 @@ self.addEventListener('fetch', function(event) {
 
     // First, remove all the ignored parameter and see if we have that URL
     // in our cache. If so, great! shouldRespond will be true.
-    var url = stripIgnoredUrlParameters(event.request.url, IgnoreUrlParametersMatching);
-    shouldRespond = UrlsToCacheKeys.has(url);
+    var url = stripIgnoredUrlParameters(event.request.url, ignoreUrlParametersMatching);
+    shouldRespond = urlsToCacheKeys.has(url);
 
     // If shouldRespond is false, check again, this time with 'index.html'
     // (or whatever the directoryIndex option is set to) at the end.
     var directoryIndex = '<%= directoryIndex %>';
     if (!shouldRespond && directoryIndex) {
       url = addDirectoryIndex(url, directoryIndex);
-      shouldRespond = UrlsToCacheKeys.has(url);
+      shouldRespond = urlsToCacheKeys.has(url);
     }
 
     // If shouldRespond is still false, check to see if this is a navigation
@@ -135,15 +135,15 @@ self.addEventListener('fetch', function(event) {
         (event.request.mode === 'navigate') &&
         isPathWhitelisted(<%= navigateFallbackWhitelist %>, event.request.url)) {
       url = new URL(navigateFallback, self.location).toString();
-      shouldRespond = UrlsToCacheKeys.has(url);
+      shouldRespond = urlsToCacheKeys.has(url);
     }
 
     // If shouldRespond was set to true at any point, then call
     // event.respondWith(), using the appropriate cache key.
     if (shouldRespond) {
       event.respondWith(
-        caches.open(CacheName).then(function(cache) {
-          return cache.match(UrlsToCacheKeys.get(url));
+        caches.open(cacheName).then(function(cache) {
+          return cache.match(urlsToCacheKeys.get(url));
         }).catch(function(e) {
           // Fall back to just fetch()ing the request if some unexpected error
           // prevented the cached response from being valid.

--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -21,7 +21,7 @@
 // for an example of how you can register this script and handle various service worker events.
 
 /* eslint-env worker, serviceworker */
-/* eslint-disable indent, no-unused-vars, no-multiple-empty-lines, max-nested-callbacks, space-before-function-paren */
+/* eslint-disable indent, no-unused-vars, no-multiple-empty-lines, max-nested-callbacks, space-before-function-paren, quotes, comma-spacing */
 'use strict';
 
 <% if (handleFetch && swToolboxCode) { %>
@@ -34,10 +34,8 @@
 importScripts(<%= importScripts %>);
 <% } %>
 
-/* eslint-disable quotes, comma-spacing */
 var PrecacheConfig = <%= precacheConfig %>;
-/* eslint-enable quotes, comma-spacing */
-var CacheNamePrefix = 'sw-precache-<%= version %>-<%= cacheId %>-' + (self.registration ? self.registration.scope : '') + '-';
+var CacheName = 'sw-precache-<%= version %>-<%= cacheId %>-' + (self.registration ? self.registration.scope : '');
 
 <% if (handleFetch) { %>
 var IgnoreUrlParametersMatching = [<%= ignoreUrlParametersMatching %>];
@@ -47,140 +45,99 @@ var IgnoreUrlParametersMatching = [<%= ignoreUrlParametersMatching %>];
 var <%- functionName %> = <%= externalFunctions[functionName] %>;
 <% }); %>
 
-var mappings = populateCurrentCacheNames(PrecacheConfig, CacheNamePrefix, self.location);
-var AbsoluteUrlToCacheName = mappings.absoluteUrlToCacheName;
-var CurrentCacheNamesToAbsoluteUrl = mappings.currentCacheNamesToAbsoluteUrl;
+var HashParamName = '_sw-precache';
+var UrlsToCacheKeys = new Map(
+  PrecacheConfig.map(function(item) {
+    var relativeUrl = item[0];
+    var hash = item[1];
+    var absoluteUrl = new URL(relativeUrl, self.location);
+    var cacheKey = createCacheKey(absoluteUrl, HashParamName, hash);
+    return [absoluteUrl.toString(), cacheKey];
+  })
+);
 
-function deleteAllCaches() {
-  return caches.keys().then(function(cacheNames) {
-    return Promise.all(
-      cacheNames.map(function(cacheName) {
-        return caches.delete(cacheName);
-      })
-    );
+function setOfCachedUrls(cache) {
+  return cache.keys().then(function(requests) {
+    return requests.map(function(request) {
+      return request.url;
+    });
+  }).then(function(urls) {
+    return new Set(urls);
   });
 }
 
 self.addEventListener('install', function(event) {
   event.waitUntil(
-    // Take a look at each of the cache names we expect for this version.
-    Promise.all(Object.keys(CurrentCacheNamesToAbsoluteUrl).map(function(cacheName) {
-      return caches.open(cacheName).then(function(cache) {
-        // Get a list of all the entries in the specific named cache.
-        // For caches that are already populated for a given version of a
-        // resource, there should be 1 entry.
-        return cache.keys().then(function(keys) {
-          // If there are 0 entries, either because this is a brand new version
-          // of a resource or because the install step was interrupted the
-          // last time it ran, then we need to populate the cache.
-          if (keys.length === 0) {
-            // Use the last bit of the cache name, which contains the hash,
-            // as the cache-busting parameter.
-            // See https://github.com/GoogleChrome/sw-precache/issues/100
-            var cacheBustParam = cacheName.split('-').pop();
-            var urlWithCacheBusting = getCacheBustedUrl(
-              CurrentCacheNamesToAbsoluteUrl[cacheName], cacheBustParam);
-
-            var request = new Request(urlWithCacheBusting,
-              {credentials: 'same-origin'});
-            return fetch(request).then(function(response) {
-              if (response.ok) {
-                return cache.put(CurrentCacheNamesToAbsoluteUrl[cacheName],
-                  response);
-              }
-
-              console.error('Request for %s returned a response status %d, ' +
-                'so not attempting to cache it.',
-                urlWithCacheBusting, response.status);
-              // Get rid of the empty cache if we can't add a successful response to it.
-              return caches.delete(cacheName);
-            });
-          }
-        });
-      });
-    })).then(function() {
-      return caches.keys().then(function(allCacheNames) {
-        return Promise.all(allCacheNames.filter(function(cacheName) {
-          return cacheName.indexOf(CacheNamePrefix) === 0 &&
-            !(cacheName in CurrentCacheNamesToAbsoluteUrl);
-          }).map(function(cacheName) {
-            return caches.delete(cacheName);
+    caches.open(CacheName).then(function(cache) {
+      return setOfCachedUrls(cache).then(function(cachedUrls) {
+        return Promise.all(
+          Array.from(UrlsToCacheKeys.values()).map(function(cacheKey) {
+            // If we don't have a key matching url in the cache already, add it.
+            if (!cachedUrls.has(cacheKey)) {
+              console.log('Adding:', cacheKey);
+              return cache.add(new Request(cacheKey, {credentials: 'same-origin'}));
+            }
           })
         );
       });
     }).then(function() {
-      if (typeof self.skipWaiting === 'function') {
-        // Force the SW to transition from installing -> active state
-        self.skipWaiting();
-      }
+      // Force the SW to transition from installing -> active state
+      return self.skipWaiting();
     })
   );
 });
 
-if (self.clients && (typeof self.clients.claim === 'function')) {
-  self.addEventListener('activate', function(event) {
-    event.waitUntil(self.clients.claim());
-  });
-}
+self.addEventListener('activate', function(event) {
+  var setOfExpectedUrls = new Set(UrlsToCacheKeys.values());
 
-self.addEventListener('message', function(event) {
-  if (event.data.command === 'delete_all') {
-    console.log('About to delete all caches...');
-    deleteAllCaches().then(function() {
-      console.log('Caches deleted.');
-      event.ports[0].postMessage({
-        error: null
+  event.waitUntil(
+    caches.open(CacheName).then(function(cache) {
+      return cache.keys().then(function(existingRequests) {
+        return Promise.all(
+          existingRequests.map(function(existingRequest) {
+            if (!setOfExpectedUrls.has(existingRequest.url)) {
+              console.log('Deleting:', existingRequest.url);
+              return cache.delete(existingRequest);
+            }
+          })
+        );
       });
-    }).catch(function(error) {
-      console.log('Caches not deleted:', error);
-      event.ports[0].postMessage({
-        error: error
-      });
-    });
-  }
+    }).then(function() {
+      return self.clients.claim();
+    })
+  );
 });
 
 <% if (handleFetch) { %>
 self.addEventListener('fetch', function(event) {
   if (event.request.method === 'GET') {
-    var urlWithoutIgnoredParameters = stripIgnoredUrlParameters(event.request.url,
-      IgnoreUrlParametersMatching);
+    // Should we call event.respondWith() inside this fetch event handler?
+    // This needs to be determined synchronously, which will give other fetch
+    // handlers a chance to handle the request if need be.
+    var shouldRespond;
 
-    var cacheName = AbsoluteUrlToCacheName[urlWithoutIgnoredParameters];
+    var url = stripIgnoredUrlParameters(event.request.url, IgnoreUrlParametersMatching);
+    shouldRespond = UrlsToCacheKeys.has(url);
+
     var directoryIndex = '<%= directoryIndex %>';
-    if (!cacheName && directoryIndex) {
-      urlWithoutIgnoredParameters = addDirectoryIndex(urlWithoutIgnoredParameters, directoryIndex);
-      cacheName = AbsoluteUrlToCacheName[urlWithoutIgnoredParameters];
+    if (!shouldRespond && directoryIndex) {
+      url = addDirectoryIndex(url, directoryIndex);
+      shouldRespond = UrlsToCacheKeys.has(url);
     }
 
     var navigateFallback = '<%= navigateFallback %>';
-    // Ideally, this would check for event.request.mode === 'navigate', but that is not widely
-    // supported yet:
-    // https://code.google.com/p/chromium/issues/detail?id=540967
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1209081
-    if (!cacheName && navigateFallback && event.request.headers.has('accept') &&
-        event.request.headers.get('accept').includes('text/html') &&
-        /* eslint-disable quotes, comma-spacing */
+    if (!shouldRespond &&
+        navigateFallback &&
+        (event.request.mode === 'navigate') &&
         isPathWhitelisted(<%= navigateFallbackWhitelist %>, event.request.url)) {
-        /* eslint-enable quotes, comma-spacing */
-      var navigateFallbackUrl = new URL(navigateFallback, self.location);
-      cacheName = AbsoluteUrlToCacheName[navigateFallbackUrl.toString()];
+      url = new URL(navigateFallback, self.location).toString();
+      shouldRespond = UrlsToCacheKeys.has(url);
     }
 
-    if (cacheName) {
+    if (shouldRespond) {
       event.respondWith(
-        // Rely on the fact that each cache we manage should only have one entry, and return that.
-        caches.open(cacheName).then(function(cache) {
-          return cache.keys().then(function(keys) {
-            return cache.match(keys[0]).then(function(response) {
-              if (response) {
-                return response;
-              }
-              // If for some reason the response was deleted from the cache,
-              // raise and exception and fall back to the fetch() triggered in the catch().
-              throw Error('The cache ' + cacheName + ' is empty.');
-            });
-          });
+        caches.open(CacheName).then(function(cache) {
+          return cache.match(UrlsToCacheKeys.get(url));
         }).catch(function(e) {
           console.warn('Couldn\'t serve response for "%s" from cache: %O', event.request.url, e);
           return fetch(event.request);

--- a/test/test.js
+++ b/test/test.js
@@ -335,32 +335,6 @@ describe('stripIgnoredUrlParameters', function() {
   });
 });
 
-describe('populateCurrentCacheNames', function() {
-  var precacheConfig = [
-    ['./', '123'],
-    ['css/main.css', 'abc']
-  ];
-  var cacheNamePrefix = 'test-prefix-';
-  var baseUrl = 'http://example.com/';
-
-  it('should return valid mappings', function(done) {
-    var expectedMappings = {
-      absoluteUrlToCacheName: {
-        'http://example.com/': 'test-prefix-http://example.com/-123',
-        'http://example.com/css/main.css': 'test-prefix-http://example.com/css/main.css-abc'
-      },
-      currentCacheNamesToAbsoluteUrl: {
-        'test-prefix-http://example.com/css/main.css-abc': 'http://example.com/css/main.css',
-        'test-prefix-http://example.com/-123': 'http://example.com/'
-      }
-    };
-    var mappings = externalFunctions.populateCurrentCacheNames(precacheConfig, cacheNamePrefix,
-      baseUrl);
-    assert.deepEqual(mappings, expectedMappings);
-    done();
-  });
-});
-
 describe('addDirectoryIndex', function() {
   var directoryIndex = 'index.html';
 
@@ -418,5 +392,17 @@ describe('isPathWhitelisted', function() {
 });
 
 describe('createCacheKey', function() {
-  var url = 'http://example.com/test/path?one=two';
+  it('should create the expected value when the original URL.search is empty', function(done) {
+    var url = 'http://example.com/test/path';
+    var cacheKey = externalFunctions.createCacheKey(url, 'name', 'value');
+    assert.strictEqual(cacheKey, 'http://example.com/test/path?name=value');
+    done();
+  });
+
+  it('should create the expected value when the original URL.search is not empty', function(done) {
+    var url = 'http://example.com/test/path?existing=value';
+    var cacheKey = externalFunctions.createCacheKey(url, 'name', 'value');
+    assert.strictEqual(cacheKey, 'http://example.com/test/path?existing=value&name=value');
+    done();
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -393,43 +393,6 @@ describe('addDirectoryIndex', function() {
   });
 });
 
-describe('getCacheBustedUrl', function() {
-  it('should append the cache-busting parameter', function(done) {
-    var url = 'http://example.com/';
-    var cacheBustedUrl = externalFunctions.getCacheBustedUrl(url);
-    assert.notStrictEqual(url, cacheBustedUrl);
-    done();
-  });
-
-  it('should produce the same output when called with the same "now" parameter', function(done) {
-    var url = 'http://example.com/';
-    var now = 123;
-    var cacheBustedUrl = externalFunctions.getCacheBustedUrl(url, now);
-    var cacheBustedUrlPrime = externalFunctions.getCacheBustedUrl(url, now);
-    assert.strictEqual(cacheBustedUrl, cacheBustedUrlPrime);
-    done();
-  });
-
-  it('should produce different output when called twice, with a delay in between', function(done) {
-    var url = 'http://example.com/';
-    var cacheBustedUrl = externalFunctions.getCacheBustedUrl(url);
-    setTimeout(function() {
-      var cacheBustedUrlPrime = externalFunctions.getCacheBustedUrl(url);
-      assert.notStrictEqual(cacheBustedUrl, cacheBustedUrlPrime);
-      done();
-    }, 2);
-  });
-
-  it('should append the URL parameter without modifying any existing parameters', function(done) {
-    var url = 'http://example.com/?one=two';
-    var cacheBustedUrl = externalFunctions.getCacheBustedUrl(url);
-    // The cache-busted URL should consist of the basic URL, followed by '&' and then the
-    // cached-busting parameters, in order to keep the same semantics.
-    assert(cacheBustedUrl.indexOf(url + '&') === 0);
-    done();
-  });
-});
-
 describe('isPathWhitelisted', function() {
   var url = 'http://example.com/test/path?one=two';
 
@@ -452,4 +415,8 @@ describe('isPathWhitelisted', function() {
     assert(externalFunctions.isPathWhitelisted([/^oops$/, /^\/test\/path$/], url));
     done();
   });
+});
+
+describe('createCacheKey', function() {
+  var url = 'http://example.com/test/path?one=two';
 });


### PR DESCRIPTION
R: @addyosmani @gauntface @wibblymat 

I think I'm happier with the code using this approach, as it also simplifies some of the logic by using `Map` and `Set`, neither of which were widely available when the code was originally written.

The one drawback that I can see is that it's no longer possible to use `caches.match()` to pick up a given `Response` from arbitrary code that the user writes, since the `Request` objects used as cache keys now have URL parameters appended to them. That's not an advertised use case, though, so I'm not worried.

This will be part of a forthcoming 4.0 release, so I'm not ready to update the `package.json` metadata yet.

Closes #86 