### PR TITLE
Fix reference to sw-toolbox.js to build/sw-toolbox.js

### DIFF
--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -181,7 +181,7 @@ function generate(params, callback) {
     var runtimeCaching;
     var swToolboxCode;
     if (params.runtimeCaching) {
-      var pathToSWToolbox = require.resolve('sw-toolbox/sw-toolbox.js');
+      var pathToSWToolbox = require.resolve('sw-toolbox/build/sw-toolbox.js');
       swToolboxCode = fs.readFileSync(pathToSWToolbox, 'utf8')
         .replace('//# sourceMappingURL=sw-toolbox.map.json', '');
 


### PR DESCRIPTION
As of sw-toolbox 3.2, the script have moved to build/. This causes an issue in our build where we're getting `Warning: Cannot find module 'sw-toolbox/sw-toolbox.js' Use --force to continue.`

That particular change to sw-toolbox is at https://github.com/GoogleChrome/sw-toolbox/commit/2d853ba80b7a7b9484161c532eda594ca0121914#diff-b9e12334e9eafd8341a6107dd98510c9L65