### PR TITLE
Always run sw-precache's fetch handler before sw-toolbox's

### DIFF
--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -183,7 +183,7 @@ function generate(params, callback) {
     if (params.runtimeCaching) {
       var pathToSWToolbox = require.resolve('sw-toolbox/sw-toolbox.js');
       swToolboxCode = fs.readFileSync(pathToSWToolbox, 'utf8')
-        .replace('//# sourceMappingURL=./build/sw-toolbox.map.json', '');
+        .replace('//# sourceMappingURL=sw-toolbox.map.json', '');
 
       runtimeCaching = params.runtimeCaching.reduce(function(prev, curr) {
         var line;

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -183,7 +183,7 @@ function generate(params, callback) {
     if (params.runtimeCaching) {
       var pathToSWToolbox = require.resolve('sw-toolbox/sw-toolbox.js');
       swToolboxCode = fs.readFileSync(pathToSWToolbox, 'utf8')
-        .replace('//# sourceMappingURL=sw-toolbox.map.json', '');
+        .replace('//# sourceMappingURL=./build/sw-toolbox.map.json', '');
 
       runtimeCaching = params.runtimeCaching.reduce(function(prev, curr) {
         var line;

--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -24,16 +24,6 @@
 /* eslint-disable indent, no-unused-vars, no-multiple-empty-lines, max-nested-callbacks, space-before-function-paren, quotes, comma-spacing */
 'use strict';
 
-<% if (handleFetch && swToolboxCode) { %>
-// *** Start of auto-included sw-toolbox code. ***
-<%= swToolboxCode %>
-// *** End of auto-included sw-toolbox code. ***
-<% } %>
-
-<% if (importScripts) { %>
-importScripts(<%= importScripts %>);
-<% } %>
-
 var precacheConfig = <%= precacheConfig %>;
 var cacheName = 'sw-precache-<%= version %>-<%= cacheId %>-' + (self.registration ? self.registration.scope : '');
 
@@ -155,9 +145,18 @@ self.addEventListener('fetch', function(event) {
   }
 });
 
+<% if (swToolboxCode) { %>
+// *** Start of auto-included sw-toolbox code. ***
+<%= swToolboxCode %>
+// *** End of auto-included sw-toolbox code. ***
+<% } %>
+
 <% if (runtimeCaching) { %>
 // Runtime cache configuration, using the sw-toolbox library.
 <%= runtimeCaching %>
 <% } %>
+<% } %>
 
+<% if (importScripts) { %>
+importScripts(<%= importScripts %>);
 <% } %>


### PR DESCRIPTION
R: @addyosmani @gauntface @wibblymat 

This reorders the `sw-toolbox` inlined code, to ensure that its `fetch` handler only runs if `sw-precache`'s handler does not call `event.respondWith()`.

This addresses an issue we were seeing in https://github.com/Polymer/docs/pull/1641 and fixes https://github.com/GoogleChrome/sw-precache/issues/128 as well.

There's a chance that folks were relying on the previous behavior (though I don't think that's a great use of `sw-precache` if they were...), so I'll call this change out explicitly in the 4.0 release notes.