### PR TITLE
supporting multiple stripPrefix & replacePrefix entries via stripPrefixMulti

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,20 @@ URL.
 
 _Default_: `''`
 
+#### stripPrefixMulti [Object]
+Maps mutliple strings to be stripped & replaced from the beginning of path URL's at runtime.
+Use this option when you have multiple discrepancies between relative paths at build time and
+the same path at run time.
+If stripPrefix and replacePrefix are not equal to `''`, they are automatically added to this option.
+```js
+stripPrefixMulti: {
+  'www-root/public-precached/': 'public/',
+  'www-root/public/': 'public/'
+}
+```
+
+_Default_: `{}`
+
 #### templateFilePath [String]
 
 The path to the  ([lo-dash](https://lodash.com/docs#template)) template used to

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -89,6 +89,7 @@ function generate(params, callback) {
       navigateFallback: '',
       navigateFallbackWhitelist: [],
       stripPrefix: '',
+      stripPrefixMulti: {},
       replacePrefix: '',
       staticFileGlobs: [],
       templateFilePath: path.join(
@@ -102,8 +103,12 @@ function generate(params, callback) {
 
     var relativeUrlToHash = {};
     var cumulativeSize = 0;
-    if (!(params.stripPrefix instanceof Array)) {
-      params.stripPrefix = [params.stripPrefix];
+    if (
+      params.stripPrefix !== '' &&
+      params.replacePrefix !== '' &&
+      Object.keys(params.stripPrefixMulti).indexOf(params.stripPrefix) === -1
+    ) {
+      params.stripPrefixMulti[params.stripPrefix] = params.replacePrefix;
     }
 
     params.staticFileGlobs.forEach(function(globPattern) {
@@ -116,8 +121,10 @@ function generate(params, callback) {
           // Strip the prefix to turn this into a relative URL.
           var relativeUrl = fileAndSizeAndHash.file
             .replace(
-              new RegExp('^(' + params.stripPrefix.map(escapeRegExp).join('|') + ')'),
-              params.replacePrefix)
+              new RegExp('^(' + Object.keys(params.stripPrefixMulti).map(escapeRegExp).join('|') + ')'),
+              function (match) {
+                return params.stripPrefixMulti[match];
+              })
             .replace(path.sep, '/');
           relativeUrlToHash[relativeUrl] = fileAndSizeAndHash.hash;
 

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -116,7 +116,7 @@ function generate(params, callback) {
           var relativeUrl = fileAndSizeAndHash.file
             .replace(
               new RegExp('^(' + Object.keys(params.stripPrefixMulti).map(escapeRegExp).join('|') + ')'),
-              function (match) {
+              function(match) {
                 return params.stripPrefixMulti[match];
               })
             .replace(path.sep, '/');

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -102,6 +102,9 @@ function generate(params, callback) {
 
     var relativeUrlToHash = {};
     var cumulativeSize = 0;
+    if (!(params.stripPrefix instanceof Array)) {
+      params.stripPrefix = [params.stripPrefix];
+    }
 
     params.staticFileGlobs.forEach(function(globPattern) {
       var filesAndSizesAndHashes = getFilesAndSizesAndHashesForGlobPattern(
@@ -113,7 +116,7 @@ function generate(params, callback) {
           // Strip the prefix to turn this into a relative URL.
           var relativeUrl = fileAndSizeAndHash.file
             .replace(
-              new RegExp('^' + escapeRegExp(params.stripPrefix)),
+              new RegExp('^(' + params.stripPrefix.map(escapeRegExp).join('|') + ')'),
               params.replacePrefix)
             .replace(path.sep, '/');
           relativeUrlToHash[relativeUrl] = fileAndSizeAndHash.hash;

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -103,13 +103,7 @@ function generate(params, callback) {
 
     var relativeUrlToHash = {};
     var cumulativeSize = 0;
-    if (
-      params.stripPrefix !== '' &&
-      params.replacePrefix !== '' &&
-      Object.keys(params.stripPrefixMulti).indexOf(params.stripPrefix) === -1
-    ) {
-      params.stripPrefixMulti[params.stripPrefix] = params.replacePrefix;
-    }
+    params.stripPrefixMulti[params.stripPrefix] = params.replacePrefix;
 
     params.staticFileGlobs.forEach(function(globPattern) {
       var filesAndSizesAndHashes = getFilesAndSizesAndHashesForGlobPattern(


### PR DESCRIPTION
The environment that I'm tinkering in with sw-precache at the moment maps requests to public/foo.txt to public-precached/foo.txt while public/bar.txt is where it says it is;

Example config:
```json
{
  "stripPrefix": ["www-root/public-precached/", "www-root/public/"],
  "replacePrefix": "public/",
}
```

Thoughts/comments?