### PR TITLE
Fix runtimeCaching urlPattern strings

### DIFF
--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -313,6 +313,6 @@ module.exports = {
   write: write
 };
 
-if (process.env.NODE_ENV === 'test') {
+if (process.env.NODE_ENV === 'swprecache-test') {
   module.exports.generateRuntimeCaching = generateRuntimeCaching;
 }

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -74,6 +74,43 @@ function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function generateRuntimeCaching(runtimeCaching) {
+  return runtimeCaching.reduce(function(prev, curr) {
+    var line;
+    if (curr.default) {
+      line = util.format('\ntoolbox.router.default = toolbox.%s;',
+        curr.default);
+    } else {
+      var urlPattern = curr.urlPattern;
+      if (typeof urlPattern === 'string') {
+        urlPattern = JSON.stringify(urlPattern);
+      }
+
+      if (!(urlPattern instanceof RegExp ||
+            typeof urlPattern === 'string')) {
+        throw new Error(
+          'runtimeCaching.urlPattern must be a string or RegExp');
+      }
+
+      line = util.format('\ntoolbox.router.%s(%s, %s, %s);',
+        // Default to setting up a 'get' handler.
+        curr.method || 'get',
+        // urlPattern might be a String or a RegExp. sw-toolbox supports both.
+        urlPattern,
+        // If curr.handler is a string, then assume it's the name of one
+        // of the built-in sw-toolbox strategies.
+        // E.g. 'networkFirst' -> toolbox.networkFirst
+        // If curr.handler is something else (like a function), then just
+        // include its body inline.
+        (typeof curr.handler === 'string' ? 'toolbox.' : '') + curr.handler,
+        // Default to no options.
+        JSON.stringify(curr.options || {}));
+    }
+
+    return prev + line;
+  }, '');
+}
+
 function generate(params, callback) {
   return new Promise(function(resolve, reject) {
     params = defaults(params || {}, {
@@ -182,39 +219,10 @@ function generate(params, callback) {
     var runtimeCaching;
     var swToolboxCode;
     if (params.runtimeCaching) {
+      runtimeCaching = generateRuntimeCaching(params.runtimeCaching);
       var pathToSWToolbox = require.resolve('sw-toolbox/sw-toolbox.js');
       swToolboxCode = fs.readFileSync(pathToSWToolbox, 'utf8')
         .replace('//# sourceMappingURL=sw-toolbox.map.json', '');
-
-      runtimeCaching = params.runtimeCaching.reduce(function(prev, curr) {
-        var line;
-        if (curr.default) {
-          line = util.format('\ntoolbox.router.default = toolbox.%s;',
-            curr.default);
-        } else {
-          if (!(curr.urlPattern instanceof RegExp ||
-                typeof curr.urlPattern === 'string')) {
-            throw new Error(
-              'runtimeCaching.urlPattern must be a string or RegExp');
-          }
-
-          line = util.format('\ntoolbox.router.%s(%s, %s, %s);',
-            // Default to setting up a 'get' handler.
-            curr.method || 'get',
-            // urlPattern might be a String or a RegExp. sw-toolbox supports both.
-            curr.urlPattern,
-            // If curr.handler is a string, then assume it's the name of one
-            // of the built-in sw-toolbox strategies.
-            // E.g. 'networkFirst' -> toolbox.networkFirst
-            // If curr.handler is something else (like a function), then just
-            // include its body inline.
-            (typeof curr.handler === 'string' ? 'toolbox.' : '') + curr.handler,
-            // Default to no options.
-            JSON.stringify(curr.options || {}));
-        }
-
-        return prev + line;
-      }, '');
     }
 
     // It's very important that running this operation multiple times with the same input files
@@ -304,3 +312,7 @@ module.exports = {
   generate: generate,
   write: write
 };
+
+if (process.env.NODE_ENV === 'test') {
+  module.exports.generateRuntimeCaching = generateRuntimeCaching;
+}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "bugs": "https://github.com/googlechrome/sw-precache/issues",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "gulp test lint",
+    "test": "NODE_ENV=test gulp test lint",
     "doctoc": "doctoc"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "bugs": "https://github.com/googlechrome/sw-precache/issues",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "NODE_ENV=test gulp test lint",
+    "test": "NODE_ENV=swprecache-test gulp test lint",
     "doctoc": "doctoc"
   },
   "files": [

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,7 @@ var assert = require('assert');
 var externalFunctions = require('../lib/functions.js');
 var fs = require('fs');
 var generate = require('../lib/sw-precache.js').generate;
+var generateRuntimeCaching = require('../lib/sw-precache.js').generateRuntimeCaching;
 var path = require('path');
 var write = require('../lib/sw-precache.js').write;
 
@@ -418,5 +419,27 @@ describe('createCacheKey', function() {
     var cacheKey = externalFunctions.createCacheKey(url, 'name', 'value', /no_match/);
     assert.strictEqual(cacheKey, 'http://example.com/test/path?existing=value&name=value');
     done();
+  });
+});
+
+describe('generateRuntimeCaching', function() {
+  it('should handle an empty array', function() {
+    assert.equal(generateRuntimeCaching([]), '');
+  });
+
+  it('should handle urlPattern string', function() {
+    var code = generateRuntimeCaching([{
+      urlPattern: '/*',
+      handler: 'testHandler'
+    }]);
+    assert.equal(code, '\ntoolbox.router.get("/*", toolbox.testHandler, {});');
+  });
+
+  it('should handle urlPattern regex', function() {
+    var code = generateRuntimeCaching([{
+      urlPattern: /test/,
+      handler: 'testHandler'
+    }]);
+    assert.equal(code, '\ntoolbox.router.get(/test/, toolbox.testHandler, {});');
   });
 });


### PR DESCRIPTION
Fixes #139.

Sorry for the refactor but I thought it would make more sense to test the runtimeCaching string generation functionality in isolation.
I'm not sure if you want to use the NODE_ENV===test check for exporting 'private' functions for testing or another option (underscore prefix?). 

Cheers