### PR TITLE
add option for each stripPrefix to have own replacePrefix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+indent_size = 2

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -112,13 +112,30 @@ function generate(params, callback) {
 
       // The files returned from glob are sorted by default, so we don't need to sort here.
       filesAndSizesAndHashes.forEach(function(fileAndSizeAndHash) {
+
+        function replaceFileName(strip, replace) {
+          return fileAndSizeAndHash.file
+            .replace(new RegExp('^(' + strip + ')'), replace)
+            .replace(path.sep, '/');
+        }
+
         if (fileAndSizeAndHash.size <= params.maximumFileSizeToCacheInBytes) {
           // Strip the prefix to turn this into a relative URL.
-          var relativeUrl = fileAndSizeAndHash.file
-            .replace(
-              new RegExp('^(' + params.stripPrefix.map(escapeRegExp).join('|') + ')'),
-              params.replacePrefix)
-            .replace(path.sep, '/');
+
+          var relativeUrl;
+
+          if (params.stripPrefix[0] instanceof Object) {
+
+            params.stripPrefix.forEach(function(prefix) {
+              if (fileAndSizeAndHash.file.indexOf(prefix[0]) !== -1) {
+                relativeUrl = replaceFileName(prefix[0], prefix[1]);
+              }
+            })
+
+          } else {
+            relativeUrl = replaceFileName(params.stripPrefix.map(escapeRegExp).join('|'));
+          }
+
           relativeUrlToHash[relativeUrl] = fileAndSizeAndHash.hash;
 
           if (params.verbose) {

--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -102,6 +102,9 @@ function generate(params, callback) {
 
     var relativeUrlToHash = {};
     var cumulativeSize = 0;
+    if (!(params.stripPrefix instanceof Array)) {
+      params.stripPrefix = [params.stripPrefix];
+    }
 
     params.staticFileGlobs.forEach(function(globPattern) {
       var filesAndSizesAndHashes = getFilesAndSizesAndHashesForGlobPattern(
@@ -113,7 +116,7 @@ function generate(params, callback) {
           // Strip the prefix to turn this into a relative URL.
           var relativeUrl = fileAndSizeAndHash.file
             .replace(
-              new RegExp('^' + escapeRegExp(params.stripPrefix)),
+              new RegExp('^(' + params.stripPrefix.map(escapeRegExp).join('|') + ')'),
               params.replacePrefix)
             .replace(path.sep, '/');
           relativeUrlToHash[relativeUrl] = fileAndSizeAndHash.hash;


### PR DESCRIPTION
**depends on #138  from @SignpostMarv**

Building off of #138, I wanted to add functionality for each each stripPrefix to have it's own replacePrefix. The use case would be having multiple "modules" that each have their own "public" directory that are all globbed into the sw.js file.

Format for stripPrefix if you'd like the functionality is as follows:

```
{
  stripPrefix: [
    [strip1, replace1],
    [strip2, replace2]
  ]
}
```

or

```
{
  stripPrefix: [
    {
      strip: stripString1,
      replace: replaceString1
    },
    {
      strip: stripString2,
      replace: replaceString2
    }
  ]
}
```