### PR TITLE
Enable overriding filePath in config and flags

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -35,7 +35,7 @@ function setDefaults(cli, configFileFlags) {
 
   compositeFlags.swFile = compositeFlags.swFile || configFileFlags.swFile ||
     'service-worker.js';
-  compositeFlags.swFilePath = path.join(compositeFlags.root,
+  compositeFlags.swFilePath = compositeFlags.swFilePath || configFileFlags.swFilePath || path.join(compositeFlags.root,
     compositeFlags.swFile);
 
   compositeFlags.cacheId = compositeFlags.cacheId ||


### PR DESCRIPTION
If using with bazel.io, the output directory for assets to cache is read-only, so you want to scan the root in blaze-out but create the sw.js file somewhere else.