### PR TITLE
Add mention of custom Gradle wrapper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,46 @@ the box. The include:
 - [`create-react-pwa`](https://github.com/jeffposnick/create-react-pwa)
 - [Web Starter Kit](https://github.com/google/web-starter-kit)
 
+### Writing a custom Gradle wrapper
+Using `sw-precache` with Gradle is rather straightforward which allows you to for example generate a service-worker for the Javadoc of your Java application.
+
+```groovy
+task generateJavadoc(type: Javadoc) {
+  <...>
+  // Specify your Javadoc options here
+  <...>
+  // After the javadoc is generated, also generate the service-worker
+  doLast {
+    try {
+      logger.lifecycle("Installing sw-precache globally")
+      exec {
+        commandLine "npm", "install", "-g", "sw-precache"
+      }
+      exec {
+        commandLine "sw-precache", "--config=sw-precache-config.json"
+      }
+      // Even though there is an option ignoreExitValue for exec, exec keeps on throwing exceptions.
+      // Therefore we just have to catch them and continue on with the build.
+    } catch(Exception ignored) {
+      logger.lifecycle("NPM is not installed. Aborting generating service-worker");
+    }
+  }
+}
+```
+An example `sw-precache-config.json` for the javadoc is:
+```json
+{
+  "staticFileGlobs": [
+    "build/javadoc/index-files/*.html",
+    "build/javadoc/js/*.js",
+    "build/javadoc/**/*.html",
+    "build/javadoc/*.html",
+    "build/javadoc/favicon.ico"
+  ],
+  "stripPrefix": "build/javadoc/",
+  "swFile": "build/javadoc/service-worker.js"
+}
+```
 
 ## Acknowledgements
 


### PR DESCRIPTION
This allows Java developers to serve the Javadoc even offline, with caching to greatly speed up the loading of their application documentation.