### PR TITLE
Allow configuring directoryIndex and navigationFallback via CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -44,6 +44,12 @@ function setDefaults(cli, configFileFlags) {
   compositeFlags.dynamicUrlToDependencies = compositeFlags.dynamicUrlToDependencies ||
     configFileFlags.dynamicUrlToDependencies;
 
+  compositeFlags.directoryIndex = compositeFlags.directoryIndex ||
+    configFileFlags.directoryIndex;
+
+  compositeFlags.navigateFallback = compositeFlags.navigateFallback ||
+    configFileFlags.navigateFallback;
+
   compositeFlags.staticFileGlobs = compositeFlags.staticFileGlobs ||
     configFileFlags.staticFileGlobs;
   if (compositeFlags.staticFileGlobs) {


### PR DESCRIPTION
These options were not working either from CLI argument or from a supplied `--config` json file.