### PR TITLE
Add a warning about editing the generated output

### DIFF
--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -19,9 +19,11 @@
 // If you need to extend the behavior of the generated service worker, the best approach is to write
 // additional code and include it using the importScripts option:
 //   https://github.com/GoogleChrome/sw-precache#importscripts-arraystring
+//
 // Alternatively, it's possible to make changes to the underlying template file and then use that as the
 // new base for generating output, via the templateFilePath option:
 //   https://github.com/GoogleChrome/sw-precache#templatefilepath-string
+//
 // If you go that route, make sure that whenever you update your sw-precache dependency, you reconcile any
 // changes made to this original template file with your modified copy.
 

--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -12,7 +12,18 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
+
+// DO NOT EDIT THIS GENERATED OUTPUT DIRECTLY!
+// This file should be overwritten as part of your build process.
+// If you need to extend the behavior of the generated service worker, the best approach is to write
+// additional code and include it using the importScripts option:
+//   https://github.com/GoogleChrome/sw-precache#importscripts-arraystring
+// Alternatively, it's possible to make changes to the underlying template file and then use that as the
+// new base for generating output, via the templateFilePath option:
+//   https://github.com/GoogleChrome/sw-precache#templatefilepath-string
+// If you go that route, make sure that whenever you update your sw-precache dependency, you reconcile any
+// changes made to this original template file with your modified copy.
 
 // This generated service worker JavaScript will precache your site's resources.
 // The code needs to be saved in a .js file at the top-level of your site, and registered


### PR DESCRIPTION
R: @addyosmani @gauntface 
CC: @jpmedley 

We should still do a better job about explaining how to extend the service worker in the docs (see https://github.com/GoogleChrome/sw-precache/issues/49), but in the meantime, maybe this warning will decrease the chance of someone manually editing the generated output.