### PR TITLE
Make the SW more resilient to caches being manually cleared.

### DIFF
--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -133,7 +133,12 @@ self.addEventListener('fetch', function(event) {
     if (shouldRespond) {
       event.respondWith(
         caches.open(cacheName).then(function(cache) {
-          return cache.match(urlsToCacheKeys.get(url));
+          return cache.match(urlsToCacheKeys.get(url)).then(function(response) {
+            if (response) {
+              return response;
+            }
+            throw Error('The cached response that was expected is missing.');
+          });
         }).catch(function(e) {
           // Fall back to just fetch()ing the request if some unexpected error
           // prevented the cached response from being valid.


### PR DESCRIPTION
R: @gauntface @addyosmani 

Fixes https://github.com/GoogleChrome/sw-precache/issues/185

If the user manually clears the contents of Cache Storage, but doesn't unregister the SW, then `sw-precache` would get into a bad state, where it didn't properly fall back to the network. This fixes that bug.

(Deep down, I knew that `cache.match()` resolves with `undefined` rather than rejecting when it doesn't match, but it's so easy to forget...)