### PR TITLE
Only run gulp build:dist if we're in production

### DIFF
--- a/app-shell-demo/package.json
+++ b/app-shell-demo/package.json
@@ -48,7 +48,7 @@
     "node": ">=5.0.0"
   },
   "scripts": {
-    "postinstall": "gulp build:dist",
+    "postinstall": "if test \"$NODE_ENV\" = \"production\"; then gulp build:dist; fi",
     "start": "node index.js"
   }
 }


### PR DESCRIPTION
R: @petele

This should fix the issue @petele was seeing when running `npm install` from within the `app-shell-demo/` directory in a freshly cloned copy of the code.