### PR TITLE
Remove the postinstall script from the app-shell-demo

### DIFF
--- a/app-shell-demo/package.json
+++ b/app-shell-demo/package.json
@@ -40,7 +40,6 @@
     "redux-promise": "^0.5.3",
     "run-sequence": "^1.2.1",
     "sw-precache": "https://github.com/GoogleChrome/sw-precache#master",
-    "sw-toolbox": "3.1.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   },

--- a/app-shell-demo/package.json
+++ b/app-shell-demo/package.json
@@ -48,7 +48,6 @@
     "node": ">=5.0.0"
   },
   "scripts": {
-    "postinstall": "gulp build:dist",
     "start": "node index.js"
   }
 }


### PR DESCRIPTION
R: @addyosmani @gauntface 

This removes the `postinstall` script from the `app-shell-demo`'s `package.json`. It was causing issues when run by end users, and is really only needed when deploying the demo to App Engine. I'll just work around that App Engine locally the next time I need to deploy.

Fixes #194 