### PR TITLE
On Windows path.join uses '\' but a '/' is needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ gulp.task('generate-service-worker', function(callback) {
   var swPrecache = require('sw-precache');
   var rootDir = 'app';
 
-  swPrecache.write(path.join(rootDir, 'service-worker.js'), {
+  swPrecache.write(`${rootDir}/service-worker.js`), {
     staticFileGlobs: [rootDir + '/**/*.{js,html,css,png,jpg,gif,svg,eot,ttf,woff}'],
     stripPrefix: rootDir
   }, callback);


### PR DESCRIPTION
Update the example code because the path.join method uses an item separator that is OS dependent. On a Windows system path.join will result in a path like this:
```
foo\bar
```
In this case the prefix is not stripped, it is isn't found because the path returned by staticFileGlobs has UNIX separators. This example code should work on all OSs.