### PR TITLE
Fix 2 typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ subdirectory of the current directory, you could run
 ```sh
 $ sw-precache --root=dist --static-file-globs='dist/**/*.html'
 ```
- 
+
 **Note:** Be sure to use quotes around parameter values that have special meanings
 to your shell (such as the `*` characters in the sample command line above,
 for example).
@@ -261,7 +261,7 @@ less flexibility:
 
 ## Runtime Caching
 
-It's often desireable, even necessary to use precaching and runtime caching together. You may have seen our [sw-toolbox](https://github.com/GoogleChrome/sw-toolbox) tool, which handles runtime caching, and wondered how to use them together. Fortunately, sw-precache handles this fro you.
+It's often desireable, even necessary to use precaching and runtime caching together. You may have seen our [sw-toolbox](https://github.com/GoogleChrome/sw-toolbox) tool, which handles runtime caching, and wondered how to use them together. Fortunately, sw-precache handles this for you.
 
 The sw-precache module has the ability to include the sw-toolbox code and configuration alongside its own configuration. Using the `runtimeCaching` configuration option in sw-precache ([see below](#runtimecaching-arrayobject)) is a shortcut that accomplishes what you could do manually by importing sw-toolbox in your service worker and writing your own routing rules.
 
@@ -271,10 +271,10 @@ The sw-precache module has the ability to include the sw-toolbox code and config
 
 The `sw-precache` module exposes two methods: `generate` and `write`.
 
-#### generate(options, callback) 
+#### generate(options, callback)
 
-`generate` takes in [options](#options), generates a service worker 
-from them and passes the result to a callback function, which must 
+`generate` takes in [options](#options), generates a service worker
+from them and passes the result to a callback function, which must
 have the following interface:
 
 `callback(error, serviceWorkerString)`
@@ -285,11 +285,11 @@ exposed by the module.
 Since 2.2.0, `generate()` also returns a
 [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
-#### write(filePath, options, callback) 
-`write` takes in [options](#options), generates a service worker from them, 
-and writes the service worker to a specified file. This method always 
-invokes `callback(error)`. If no error was found, the `error` parameter will 
-be `null'
+#### write(filePath, options, callback)
+`write` takes in [options](#options), generates a service worker from them,
+and writes the service worker to a specified file. This method always
+invokes `callback(error)`. If no error was found, the `error` parameter will
+be `null`
 
 Since 2.2.0, `write()` also returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
@@ -317,13 +317,13 @@ navigation.
 
 _Default_: `true`
 
-#### directoryIndex [String] 
-Sets a default filename to return for URL's formatted like directory paths (in 
-other words, those ending in `'/'`). `sw-precache` will take that translation 
+#### directoryIndex [String]
+Sets a default filename to return for URL's formatted like directory paths (in
+other words, those ending in `'/'`). `sw-precache` will take that translation
 into account and serve the contents a relative `directoryIndex` file when 
-there's no other match for a URL ending in `'/'`. To turn off this behavior, 
-set `directoryIndex` to `false` or `null`. To override this behavior for one 
-or more URLs, use the `dynamicUrlToDependencies` option to explicitly set up 
+there's no other match for a URL ending in `'/'`. To turn off this behavior,
+set `directoryIndex` to `false` or `null`. To override this behavior for one
+or more URLs, use the `dynamicUrlToDependencies` option to explicitly set up
 mappings between a directory URL and a corresponding file.
 
 _Default_: `'index.html'`
@@ -365,10 +365,10 @@ the templates `layout.jade` and `home.jade`, then specify `'/pages/home':
 
 _Default_: `{}`
 
-#### handleFetch [boolean] 
-Determines whether the `fetch` event handler is included in the generated 
-service worker code. It is useful to set this to `false` in development builds, 
-to ensure that features like live reload still work. Otherwise, the content 
+#### handleFetch [boolean]
+Determines whether the `fetch` event handler is included in the generated
+service worker code. It is useful to set this to `false` in development builds,
+to ensure that features like live reload still work. Otherwise, the content
 would always be served from the service worker cache.
 
 _Default_: `true`
@@ -384,14 +384,14 @@ To ignore all parameters, use `[/./]`. To take all parameters into account when 
 
 _Default_: `[/^utm_/]`
 
-#### importScripts [Array&#x27e8;String&#x27e9;] 
+#### importScripts [Array&#x27e8;String&#x27e9;]
 Writes calls to [`importScripts()`]
-(https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/basic_usage#Importing_scripts_and_libraries) 
+(https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/basic_usage#Importing_scripts_and_libraries)
 to the resulting service worker to import the specified scripts.
 
 _Default_: `[]`
 
-#### logger [function] 
+#### logger [function]
 
 Specifies a callback function for logging which resources are being precached and
 a precache size. Use `function() {}` if you'd prefer that nothing is logged.
@@ -404,7 +404,7 @@ Sets the maximum allowed size for a file in the precache list.
 
 _Default_: `2097152` (2 megabytes)
 
-#### navigateFallback [String] 
+#### navigateFallback [String]
 Sets an HTML document to use as a fallback for URLs not found in the cache. To
 be effective, this fallback URL should be already cached via `staticFileGlobs`
 or `dynamicUrlToDependencies`.
@@ -421,7 +421,7 @@ the request is a navigation.
 
 _Default_: `''`
 
-#### navigateFallbackWhitelist [Array&#x27e8;RegExp&#x27e9;] 
+#### navigateFallbackWhitelist [Array&#x27e8;RegExp&#x27e9;]
 Works to limit the effect of `navigateFallback`, so that the fallback only
 applies to requests for URLs with paths that match at least one
 [`RegExp`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp).
@@ -522,7 +522,7 @@ You'll almost always want to specify something for this.
 
 _Default_: `[]`
 
-#### stripPrefix [String] 
+#### stripPrefix [String]
 Removes a specified string from the beginning of path URL's at runtime. Use this
 option when there's a discrepancy between a relative path at build time and
 the same path at run time. For example, if all your local files are under
@@ -601,8 +601,8 @@ Thanks to [Sindre Sorhus](https://github.com/sindresorhus) and
 
 Copyright © 2016 Google, Inc.
 
-Licensed under the [Apache License, Version 2.0](LICENSE) (the "License"); 
-you may not use this file except in compliance with the License. You may 
+Licensed under the [Apache License, Version 2.0](LICENSE) (the "License");
+you may not use this file except in compliance with the License. You may
 obtain a copy of the License at
 
    http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
When reading the docs last night I came across two real small typos, decided to fix 'em. Also some random trailing whitespace got eliminated in the process thanks to Atom.