### PR TITLE
Cli : set defaults : field `stripPrefixMulti`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,6 +34,9 @@ function setDefaults(cli, configFileFlags) {
   compositeFlags.stripPrefix = compositeFlags.stripPrefix ||
     configFileFlags.stripPrefix || compositeFlags.root;
 
+  compositeFlags.stripPrefixMulti = compositeFlags.stripPrefixMulti ||
+    configFileFlags.stripPrefixMulti || {};
+
   compositeFlags.swFile = compositeFlags.swFile || configFileFlags.swFile ||
     'service-worker.js';
   compositeFlags.swFilePath = compositeFlags.swFilePath ||


### PR DESCRIPTION
The field `stripPrefixMulti` not working when we use the command-line interface