### PR TITLE
fix: set navigateFallbackWhitelist from config

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -56,6 +56,9 @@ function setDefaults(cli, configFileFlags) {
   compositeFlags.navigateFallback = compositeFlags.navigateFallback ||
     configFileFlags.navigateFallback;
 
+  compositeFlags.navigateFallbackWhitelist = compositeFlags.navigateFallbackWhitelist ||
+    configFileFlags.navigateFallbackWhitelist;
+
   compositeFlags.staticFileGlobs = compositeFlags.staticFileGlobs ||
     configFileFlags.staticFileGlobs;
   if (compositeFlags.staticFileGlobs) {


### PR DESCRIPTION
We encountered an issue where the fallback white list would always be written as an empty array no matter what the config file specified. This change fixes that.