### PR TITLE
Explicitly set `redirect: follow` on the precaching requests.

### DIFF
--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -77,7 +77,10 @@ self.addEventListener('install', function(event) {
           Array.from(urlsToCacheKeys.values()).map(function(cacheKey) {
             // If we don't have a key matching url in the cache already, add it.
             if (!cachedUrls.has(cacheKey)) {
-              return cache.add(new Request(cacheKey, {credentials: 'same-origin'}));
+              return cache.add(new Request(cacheKey, {
+                credentials: 'same-origin',
+                redirect: 'follow'
+              }));
             }
           })
         );


### PR DESCRIPTION
R: @addyosmani @gauntface 

The default mode for `redirect` is `'follow'`, as per the [Fetch API specification](https://fetch.spec.whatwg.org/#concept-request-redirect-mode).

However, as per #220, that default behavior doesn't appear to be universally applied, in particular in older versions of Chrome and in more recent versions of Firefox.

This PR changes precaching requests to explicitly set `redirect: 'follow'` to ensure that the behavior is consistent instead of relying on the browser default. Since that was what I had expected the behavior to be already (in browsers following the spec), I think this should be a "safe" change, and will roll it out with an accompanying minor version bump.

Fixes #220 