### PR TITLE
Update to require at least node 4.0.0.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,9 @@
     "no-console": 0,
     "no-inline-comments": 0,
     "space-before-function-paren": [2, "never"],
-    "require-jsdoc": 0
+    "require-jsdoc": 0,
+    "no-var": 0,
+    "comma-dangle": 0,
+    "max-len": ["error", { "ignoreComments": true }]
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
   - "node"

--- a/demo/Gruntfile.js
+++ b/demo/Gruntfile.js
@@ -53,9 +53,11 @@ module.exports = function(grunt) {
   }
 
   grunt.registerMultiTask('swPrecache', function() {
+    /* eslint-disable no-invalid-this */
     var done = this.async();
     var rootDir = this.data.rootDir;
     var handleFetch = this.data.handleFetch;
+    /* eslint-enable */
 
     writeServiceWorkerFile(rootDir, handleFetch, function(error) {
       if (error) {

--- a/package.json
+++ b/package.json
@@ -19,24 +19,24 @@
     "pwa"
   ],
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.0.0"
   },
   "devDependencies": {
     "del": "^2.2.2",
-    "eslint": "^1.10.3",
-    "eslint-config-google": "^0.3.0",
-    "express": "^4.14.0",
-    "gh-pages": "^0.11.0",
+    "eslint": "^3.15.0",
+    "eslint-config-google": "^0.7.1",
+    "express": "^4.14.1",
+    "gh-pages": "^0.12.0",
     "grunt": "^1.0.1",
     "gulp": "^3.9.1",
     "gulp-doctoc": "^0.1.4",
-    "gulp-eslint": "^1.0.0",
-    "gulp-load-plugins": "^1.3.0",
+    "gulp-eslint": "^3.0.1",
+    "gulp-load-plugins": "^1.5.0",
     "gulp-mocha": "^3.0.1",
     "gulp-replace": "^0.5.4",
-    "gulp-util": "^3.0.7",
+    "gulp-util": "^3.0.8",
     "jade": "^1.11.0",
-    "mocha": "^3.1.2",
+    "mocha": "^3.2.0",
     "node-fetch": "^1.6.3",
     "run-sequence": "^1.2.2"
   },
@@ -48,7 +48,7 @@
     "lodash.template": "^4.4.0",
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",
-    "pretty-bytes": "^3.0.1",
+    "pretty-bytes": "^4.0.2",
     "sw-toolbox": "^3.4.0"
   },
   "repository": "googlechrome/sw-precache",


### PR DESCRIPTION
R: @addyosmani @gauntface 

This drops support for node 0.12.x, and imposes a minimum version of node 4.0.0 via the `engines` field in `package.json`.

node 0.12.x [reached its official end-of-life](https://github.com/nodejs/LTS#lts-schedule) at the end of 2016.

Since we can now assume node 4+, there are a few dependencies that we can now update that assume node 4+ functionality.

This includes updates to our default `eslint` rules. I've explicitly disabled some of the new default rules for this project, since, e.g., updating all of our `var` to `const`/`let` is outside of the scope of work we want to do with `sw-precache`.

This change will be rolled into an upcoming major version bump (to 5.0.0) release of `sw-precache`.

Fixes #203 