### PR TITLE
Match the cache-bust check against the URL's pathname

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,9 +349,14 @@ is not needed, and can be safely excluded.
 `dontCacheBustUrlsMatching` gives you a way of opting-in to skipping the cache
 busting behavior for a subset of your URLs (or all of them, if a catch-all value
 like `/./` is used).
-If set, then each URL that's prefetched will be matched against this value.
+If set, then the [pathname](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/pathname)
+of each URL that's prefetched will be matched against this value.
 If there's a match, then the URL will be prefetched as-is, without an additional
 cache-busting URL parameter appended.
+
+Note: Prior to `sw-precache` v5.0.0, `dontCacheBustUrlsMatching` matched against
+the entire request URL. As of v5.0.0, it only matches against the URL's
+[pathname](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/pathname).
 
 _Default_: not set
 

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -71,7 +71,7 @@ module.exports = {
     // If dontCacheBustUrlsMatching is not set, or if we don't have a match,
     // then add in the extra cache-busting URL parameter.
     if (!dontCacheBustUrlsMatching ||
-        !(url.toString().match(dontCacheBustUrlsMatching))) {
+        !(url.pathname.match(dontCacheBustUrlsMatching))) {
       url.search += (url.search ? '&' : '') +
         encodeURIComponent(paramName) + '=' + encodeURIComponent(paramValue);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -410,14 +410,21 @@ describe('createCacheKey', function() {
     done();
   });
 
-  it('should not append the parameter when the URL matches the exclusion pattern', function(done) {
+  it('should append the parameter when the origin matches the exclusion pattern, but the pathname does not match', function(done) {
     var url = 'http://example.com/test/path?existing=value';
     var cacheKey = externalFunctions.createCacheKey(url, 'name', 'value', /example/);
-    assert.strictEqual(cacheKey, url);
+    assert.strictEqual(cacheKey, 'http://example.com/test/path?existing=value&name=value');
     done();
   });
 
-  it('should append the parameter when the URL does not match the exclusion pattern', function(done) {
+  it('should not append the parameter when the pathname matches the exclusion pattern', function(done) {
+    var url = 'http://example.com/test/path?existing=value';
+    var cacheKey = externalFunctions.createCacheKey(url, 'name', 'value', /test\/path/);
+    assert.strictEqual(cacheKey, 'http://example.com/test/path?existing=value');
+    done();
+  });
+
+  it('should append the parameter when the pathname does not match the exclusion pattern', function(done) {
     var url = 'http://example.com/test/path?existing=value';
     var cacheKey = externalFunctions.createCacheKey(url, 'name', 'value', /no_match/);
     assert.strictEqual(cacheKey, 'http://example.com/test/path?existing=value&name=value');


### PR DESCRIPTION
R: @gauntface @addyosmani 
CC: @bgrzys

This was always the intention, as the pattern is meant to pick up hashes in filenames. Folks have reported that a pattern like `/\.\w{8}\./` accidentally matched against the the URL's origin for certain domain names.

This will be rolled up into the pending 5.0.0 release.

Fixes #240