### PR TITLE
added: ability to supply html string as dependency for dynamicUrlToDependencies

### DIFF
--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -188,47 +188,61 @@ function generate(params, callback) {
     });
 
     Object.keys(params.dynamicUrlToDependencies).forEach(function(dynamicUrl) {
-      if (!Array.isArray(params.dynamicUrlToDependencies[dynamicUrl])) {
+      var dependency = params.dynamicUrlToDependencies[dynamicUrl];
+      var isString = typeof dependency === 'string';
+
+      if (!Array.isArray(dependency) && !isString) {
         throw Error(util.format(
           'The value for the dynamicUrlToDependencies.%s ' +
-          'option must be an Array.',
+          'option must be an Array or a String.',
           dynamicUrl));
       }
 
-      var filesAndSizesAndHashes = params.dynamicUrlToDependencies[dynamicUrl]
-        .sort()
-        .map(function(file) {
-          try {
-            return getFileAndSizeAndHashForFile(file);
-          } catch (e) {
-            // Provide some additional information about the failure if the file is missing.
-            if (e.code === 'ENOENT') {
-              params.logger(util.format(
-                '%s was listed as a dependency for dynamic URL %s, but ' +
-                'the file does not exist. Either remove the entry as a ' +
-                'dependency, or correct the path to the file.',
-                file, dynamicUrl
-              ));
+      if (isString) {
+        cumulativeSize += dependency.length;
+        relativeUrlToHash[dynamicUrl] = getHash(dependency);
+      } else {
+        var filesAndSizesAndHashes = dependency
+          .sort()
+          .map(function(file) {
+            try {
+              return getFileAndSizeAndHashForFile(file);
+            } catch (e) {
+              // Provide some additional information about the failure if the file is missing.
+              if (e.code === 'ENOENT') {
+                params.logger(util.format(
+                  '%s was listed as a dependency for dynamic URL %s, but ' +
+                  'the file does not exist. Either remove the entry as a ' +
+                  'dependency, or correct the path to the file.',
+                  file, dynamicUrl
+                ));
+              }
+              // Re-throw the exception unconditionally, since this should be treated as fatal.
+              throw e;
             }
-            // Re-throw the exception unconditionally, since this should be treated as fatal.
-            throw e;
-          }
+          });
+        var concatenatedHashes = '';
+
+        filesAndSizesAndHashes.forEach(function(fileAndSizeAndHash) {
+          // Let's assume that the response size of a server-generated page is roughly equal to the
+          // total size of all its components.
+          cumulativeSize += fileAndSizeAndHash.size;
+          concatenatedHashes += fileAndSizeAndHash.hash;
         });
-      var concatenatedHashes = '';
 
-      filesAndSizesAndHashes.forEach(function(fileAndSizeAndHash) {
-        // Let's assume that the response size of a server-generated page is roughly equal to the
-        // total size of all its components.
-        cumulativeSize += fileAndSizeAndHash.size;
-        concatenatedHashes += fileAndSizeAndHash.hash;
-      });
-
-      relativeUrlToHash[dynamicUrl] = getHash(concatenatedHashes);
+        relativeUrlToHash[dynamicUrl] = getHash(concatenatedHashes);
+      }
 
       if (params.verbose) {
-        params.logger(util.format(
-          'Caching dynamic URL "%s" with dependencies on %j',
-          dynamicUrl, params.dynamicUrlToDependencies[dynamicUrl]));
+        if (isString) {
+          params.logger(util.format(
+            'Caching dynamic URL "%s" with dependency on user-supplied string',
+            dynamicUrl));
+        } else {
+          params.logger(util.format(
+            'Caching dynamic URL "%s" with dependencies on %j',
+            dynamicUrl, dependency));
+        }
       }
     });
 


### PR DESCRIPTION
First off thanks @jeffposnick and co for your work on this awesome lib!

This PR addresses the use-case I mentioned here: https://github.com/GoogleChrome/sw-precache/issues/156#issuecomment-284581262

To summarize, we have a scenario where we don't have a static "base" html file or even a template file that changes each time the cached "dynamicUrl" should be considered changed. Instead, our dependency is really the resulting HTML string that we generate for that environment. The `/` dynamic route that we're trying to precache is the result of an aggregated environment-specific config object and an HTML template. I could list out a set of config files that is used to aggregate that config, but doing so would be brittle and error prone. Instead, this suggested change enables passing the contents of the file itself as a dependency for the `dynamicUrlToDependencies` option. 

So if the `sw-precache` library gets a string instead of an array it will use *that* to generate a hash, and add it to the total size. 

This PR represents the change I've made locally to make this work for us. So far it's working well for us and I'd love to see this adopted upsteam. If this looks/sounds reasonable to you, I'll tack on some updates to the docs as well. I just wanted to float the idea first before I spend time on that.

Please let me know what you think when you have a sec. Thanks!