### PR TITLE
pass importScripts as array to template

### DIFF
--- a/lib/sw-precache.js
+++ b/lib/sw-precache.js
@@ -293,8 +293,7 @@ function generate(params, callback) {
         externalFunctions: externalFunctions,
         handleFetch: params.handleFetch,
         ignoreUrlParametersMatching: params.ignoreUrlParametersMatching,
-        importScripts: params.importScripts ?
-          params.importScripts.map(JSON.stringify).join(',') : null,
+        importScripts: params.importScripts || null,
         // Ensure that anything false is translated into '', since this will be treated as a string.
         navigateFallback: params.navigateFallback || '',
         navigateFallbackWhitelist:

--- a/service-worker.tmpl
+++ b/service-worker.tmpl
@@ -192,5 +192,5 @@ self.addEventListener('fetch', function(event) {
 <% } %>
 
 <% if (importScripts) { %>
-importScripts(<%= importScripts %>);
+importScripts(<%= importScripts.map(JSON.stringify).join(',') %>);
 <% } %>


### PR DESCRIPTION
This allows better customization for how scripts are imported in templates.